### PR TITLE
Use Standard for Public Code as name consistently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We love issues and pull requests from everyone.
 
 ## Problems, suggestions and questions in Issues
 
-Please help development by reporting problems, suggesting changes and asking questions. To do this, you can [create a GitHub Issue](https://help.github.com/articles/creating-an-issue/) for this project in the [GitHub Issues for the Public Code Standard](https://github.com/publiccodenet/standard/issues).
+Please help development by reporting problems, suggesting changes and asking questions. To do this, you can [create a GitHub Issue](https://help.github.com/articles/creating-an-issue/) for this project in the [GitHub Issues for the Standard for Public Code](https://github.com/publiccodenet/standard/issues).
 
 You don't need to change any of our code or documentation to be a contributor!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Public Code Standard
+# Standard for Public Code
 
-The Public Code Standard is a method for developing civic and source code for public purposes.
+The Standard for Public Code is a method for developing civic and source code for public purposes.
 
 ## Help improve this standard
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 remote_theme: publiccodenet/jekyll-theme
-title: Public Code Standard
+title: Standard for Public Code
 
 include: 
   - "README.md"

--- a/introduction.md
+++ b/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The Public Code Standard is a method for developing civic and source code for public purposes.
+The Standard for Public Code is a method for developing civic and source code for public purposes.
 
 ## The goal of this publication
 


### PR DESCRIPTION
Uses one name consistently. Fixes #4