### PR TITLE
took out 'current version'

### DIFF
--- a/criteria/coding-in-the-open.md
+++ b/criteria/coding-in-the-open.md
@@ -24,7 +24,7 @@ order: 1
 
 ## How to test
 
-* The source code is published on the internet where it can be seen from outside the original contributing organization and without the need for any form of authentication
+* The source for any version currently in use is published on the internet where it can be seen from outside the original contributing organization and without the need for any form of authentication
 
 ## Policy makers: what you need to do
 

--- a/criteria/coding-in-the-open.md
+++ b/criteria/coding-in-the-open.md
@@ -24,7 +24,7 @@ order: 1
 
 ## How to test
 
-* The current version of the source is published on the internet where it can be seen from outside the original contributing organization and without the need for any form of authentication
+* The source code is published on the internet where it can be seen from outside the original contributing organization and without the need for any form of authentication
 
 ## Policy makers: what you need to do
 


### PR DESCRIPTION
This ‘current version’ phrase confuses me as there seems to be an ever-changing version, because anyone can make changes at any time, forever. Maybe better to write something like: We publish the source on the internet where… Or even: We publish the ever-developing source…
and.. i snuck back in the word 'code' after 'source'.