### PR TITLE
public policy and reduce requirements

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -8,7 +8,7 @@ order: 2
 
 * A codebase MUST include all the policy that the source code is based upon
 * A codebase MUST include all source code that the policy is based upon
-* All policy and source code that the codebase is based upon MUST be documented, reusable and portable
+* All public policy and source code that the codebase is based upon MUST be documented, reusable and portable
 * Policy SHOULD be provided in machine readable and unambiguous formats
 * Continuous integration tests SHOULD validate the source code and the policy are executed coherently
 


### PR DESCRIPTION
also: 
does the 3rd requirement make the 1rst and 2nd redundant?
('All policy and source code that the codebase is based upon MUST be documented, reusable and portable' seems to ask for inclusion of policy and code?)