### PR TITLE
facilitate reuse

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -14,7 +14,7 @@ order: 2
 
 ## What this does
 
-* Make sure anyone has access to both the source and civic code necessary to effectively reuse a codebase
+* Make sure access is guaranteed to both the source code and the public policy documents to facilitate effective reuse of a codebase
 
 ## What this does not do
 


### PR DESCRIPTION
took out 'anyone' (too generic)
replaced civic code with public policy documents
used 'facilitate' b/c this access is a necessary not a sufficient condition.