### PR TITLE
Add active community to Criteria

### DIFF
--- a/criteria/active-community.md
+++ b/criteria/active-community.md
@@ -1,0 +1,44 @@
+---
+order: 15
+---
+# Foster an active community
+
+## Requirements
+
+* Software MUST be in use by multiple parties
+* Communication channels MUST exist for users AND developers
+* The roadmap SHOULD be influenced by the needs of multiple parties
+* MAY hold regular events
+
+## Why this is important
+
+* Members of active communities support each other.
+* Codebases without communities are either too narrow for stewardship by the Foundation for Public code or must continue under incubation until a self-sustaining community can be built.
+
+## What this does not do
+
+* This does not shift responsibility for documentation, support, bug-fixing, or anything else to an unpaid community.
+
+## How to test
+
+* Count known users
+* Count messages per week
+* Count commits per week
+* Count distinct commit authors per week
+* Graph bug time-to-resolution over time
+* Count bugs and feature requests opened over time
+
+## Policy makers: what you need to do
+
+* Policy makers should ensure that their organization is listed in the known users.
+
+## Management: what you need to do
+
+* Ensure awareness of the community
+* Track and publish metrics
+
+## Developers and designers: what you need to do
+* Track and publish code metrics
+
+## Further reading
+* [Top 5 open source community metrics to track] (https://opensource.com/business/15/12/top-5-open-source-community-metrics-track)

--- a/index.md
+++ b/index.md
@@ -24,6 +24,7 @@ The Standard for Public Code gives cities a model for building their own open so
   * [Publish with an open license](criteria/open-licenses.md)
   * [Use a coherent style](criteria/style.md)
   * [Pay attention to codebase maturity](criteria/advertise-maturity.md)
+  * [Foster an active community] (criteria/active-community.md)
 * [Authors](AUTHORS.md)
 * [Contributing guide](CONTRIBUTING.md)
 * [Code of conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
For a project to move from Incubation to Full Stewardship, it must have
more than the code quality criteria currently enumerated, it must also
have a high enough level of dimensions such as community and process.

This commit is a first sketch of what it means to have an active community.