### PR TITLE
Add Contributor License Agreement in Welcome Contributions

### DIFF
--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -13,6 +13,7 @@ order: 4
 * The codebase MUST include an email address for security issues and responsible disclosure
 * The codebase MUST include contribution guidelines explaining how contributors can get involved
 * The codebase SHOULD have a publicly available roadmap
+* The codebase SHOULD have a contributor license agreement
 * The codebase SHOULD advertize the committed engagement of involved organizations in the development and maintenance
 * The codebase MAY include a code of conduct for contributors
 * The codebase MAY document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file
@@ -23,6 +24,7 @@ order: 4
 * Prevents forks of codebases, in which a community that works on a project splits because there is no shared progress
 * Helps users decide to use one codebase over another
 * Enables users to fix problems and add features to the shared codebase leading to better, more reliable and feature rich software
+* Helps organizations governing the codebase to act on legal issues regarding the codebase, for example license violations
 
 ## What this does not do
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -13,8 +13,8 @@ order: 4
 * The codebase MUST include an email address for security issues and responsible disclosure
 * The codebase MUST include contribution guidelines explaining how contributors can get involved
 * The codebase SHOULD have a publicly available roadmap
-* The codebase SHOULD have a contributor license agreement
 * The codebase SHOULD advertize the committed engagement of involved organizations in the development and maintenance
+* The codebase MAY have a contributor license agreement
 * The codebase MAY include a code of conduct for contributors
 * The codebase MAY document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file
 


### PR DESCRIPTION
- A signed contributor license agreement should be used as a condition for approving contributions.
- By signing the agreement the contributor warrants to be the copyright owner of the contribution.
- The contributor grants organization(s) governing the codebase copyright license to use the moral copyrights of the Contributor vested in the Submission.
- Without a contributor license agreement governing organization(s) are not able to take certain actions without the approval of all contributors, for example changing the license of the code base.