### PR TITLE
Code is in use by multiple parties

### DIFF
--- a/codebase-criteria/reusable-and-portable-codebases.md
+++ b/codebase-criteria/reusable-and-portable-codebases.md
@@ -8,6 +8,7 @@ order: 3
 
 * The codebase MUST be developed to be reusable in different contexts
 * The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding
+* The codebase MUST be in use by multiple parties
 * Code SHOULD be general purpose and SHOULD be configurable
 * Codebases SHOULD include a [publiccode.yml](https://github.com/italia/publiccode.yml) metadata description so that they're easily discoverable
 * Code and its documentation SHOULD not contain situation-specific information. For example, personal and organizational data as well as tokens and passwords used in the production system should never be included.
@@ -17,19 +18,23 @@ order: 3
 * Enables other policy makers, developers and designers to reuse what you've developed, to test it, to improve it and contribute those improvements back leading to better quality, cheaper maintainability and higher reliability.
 * Makes the code easier for new people to understand (as it's more general)
 * Makes it easier to control the mission, vision and scope of the codebase because the codebase is thoughtfully and purposefully designed for reusability
+* Codebases used by multiple parties have broad enough value to be Public Code and are more likely to benefit from a self-sustaining community.
 
 ## What this does not do
 
 * Get others to reuse the codebase
 * Build a community
+* Shift responsibility for documentation, support, bug-fixing, etc. to another party
 
 ## How to test
 
 * Ask someone in a similar role at another organization if they could reuse your codebase and what that would entail
+* Codebase is in use by multiple parties or in multiple contexts
 
 ## Policy makers: what you need to do
 
 * Document your policy with enough clarity and detail that it can be understood outside of its original context
+* Make sure your organization is listed as a known user by the project
 
 ## Management: what you need to do
 

--- a/codebase-criteria/reusable-and-portable-codebases.md
+++ b/codebase-criteria/reusable-and-portable-codebases.md
@@ -9,6 +9,7 @@ order: 3
 * The codebase MUST be developed to be reusable in different contexts
 * The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding
 * The codebase MUST be in use by multiple parties
+* The roadmap SHOULD be influenced by the needs of multiple parties
 * Code SHOULD be general purpose and SHOULD be configurable
 * Codebases SHOULD include a [publiccode.yml](https://github.com/italia/publiccode.yml) metadata description so that they're easily discoverable
 * Code and its documentation SHOULD not contain situation-specific information. For example, personal and organizational data as well as tokens and passwords used in the production system should never be included.


### PR DESCRIPTION
Codebases without communinities are either too narrow for stewardship or
must continue under incubation until a self-sustaining community can be
built.

-----
[View rendered codebase-criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/multi-party/codebase-criteria/reusable-and-portable-codebases.md)