### PR TITLE
Rename continuous "delivery" to "integration"

### DIFF
--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -2,7 +2,7 @@
 order: 11
 ---
 
-# Use continuous delivery
+# Use continuous integration
 
 ## Requirements
 
@@ -16,7 +16,7 @@ order: 11
 
 ## Why this is important
 
-* Using continuous delivery:
+* Using continuous integration:
   * allows you to quickly identify problems with your codebase
   * enable risk taking and focusing on problem solving while minimising stress on the contributors
   * lowers barriers for new contributors by reducing the amount of understanding necessary to suggest changes
@@ -60,6 +60,7 @@ order: 11
 
 ## Further reading
 
+* [What is continuous integration](https://www.martinfowler.com/articles/continuousIntegration.html) by Martin Fowler
 * [What is continuous delivery](https://www.continuousdelivery.com/) by Jez Humble
 * [Use continuous delivery](https://gds-way.cloudapps.digital/standards/continuous-delivery.html) by the UK Government Digital Service
 * [Quality assurance: testing your service regularly](https://www.gov.uk/service-manual/technology/quality-assurance-testing-your-service-regularly) by the Government Digital Service (United Kingdom)

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ The Standard for Public Code gives cities a model for building their own open so
   * [Document your code](criteria/documenting.md)
   * [Use plain English](criteria/understandable-english-first.md)
   * [Use open standards](criteria/open-standards.md)
-  * [Use continuous delivery](criteria/continuous-delivery.md)
+  * [Use continuous integration](criteria/continuous-integration.md)
   * [Publish with an open license](criteria/open-licenses.md)
   * [Use a coherent style](criteria/style.md)
   * [Pay attention to codebase maturity](criteria/advertise-maturity.md)


### PR DESCRIPTION
Issue https://github.com/publiccodenet/standard/issues/236 rightly
notes that these requirements are focused on the CI aspects of CICD.

-----
[View rendered criteria/continuous-integration.md](https://github.com/publiccodenet/standard/blob/rename-cd-to-ci/criteria/continuous-integration.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/rename-cd-to-ci/index.md)