### PR TITLE
Added license in the metadata of the files 

### DIFF
--- a/assets/codebase.svg
+++ b/assets/codebase.svg
@@ -1,4 +1,20 @@
-<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata id="metadata5">
+  <rdf:RDF>
+     <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+          <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title></dc:title>
+          <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+     </cc:Work>
+     <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+     </cc:License>
+  </rdf:RDF>
+</metadata>
 <g clip-path="url(#clip0)">
 <rect width="595" height="842" fill="#00BA8D"/>
 <path d="M275.383 549.165L275.383 602.307C275.383 608.457 272.553 614.265 267.71 618.056L233.53 644.809C228.299 648.903 225.243 655.177 225.243 661.82V661.82C225.243 667.785 220.407 672.621 214.442 672.621L-121 672.621" stroke="#FFF500" stroke-linecap="round" stroke-linejoin="round"/>

--- a/assets/codebase.svg
+++ b/assets/codebase.svg
@@ -5,7 +5,7 @@
      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
           <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-          <dc:title></dc:title>
+          <dc:title>Public code codebase</dc:title>
           <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
      </cc:Work>
      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">

--- a/assets/collaboration.svg
+++ b/assets/collaboration.svg
@@ -1,4 +1,20 @@
-<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata id="metadata5">
+    <rdf:RDF>
+       <cc:Work rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+            <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+            <dc:title></dc:title>
+            <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+       </cc:Work>
+       <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+            <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+            <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+            <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+       </cc:License>
+    </rdf:RDF>
+</metadata>
 <g clip-path="url(#clip0)">
 <rect width="595" height="842" fill="#56CCF2"/>
 <path d="M353.189 555.208L596 582L596 468.549L375.081 490.445C346.189 493.309 317.545 483.002 297.102 462.386L280.734 445.879C274.147 439.236 262.932 441.355 259.222 449.943C254.345 461.237 243.221 468.549 230.92 468.549L188.2 468.549C185.843 468.549 183.559 469.369 181.739 470.867L180.733 471.695C176.705 475.011 175.332 480.578 177.356 485.386C178.721 488.63 178.035 492.374 175.609 494.923L172.819 497.854C168.788 502.089 168.074 508.491 171.072 513.511C172.851 516.49 172.917 520.189 171.243 523.229L170.434 524.699C167.735 529.602 168.162 535.631 171.525 540.105C173.964 543.351 174.9 547.484 174.097 551.464L173.976 552.066C172.729 558.246 176.606 564.302 182.74 565.758L236.333 578.475C246.015 580.773 256.162 580.129 265.476 576.627L307.025 561.003C321.744 555.469 337.559 553.484 353.189 555.208Z" fill="#FFB7B7"/>

--- a/assets/collaboration.svg
+++ b/assets/collaboration.svg
@@ -5,7 +5,7 @@
        <cc:Work rdf:about="">
           <dc:format>image/svg+xml</dc:format>
             <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-            <dc:title></dc:title>
+            <dc:title>Collaboration on public code</dc:title>
             <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
        </cc:Work>
        <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">

--- a/assets/collaborative-developement.svg
+++ b/assets/collaborative-developement.svg
@@ -5,7 +5,7 @@
      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
           <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-          <dc:title></dc:title>
+          <dc:title>collaborative public code development</dc:title>
           <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
      </cc:Work>
      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">

--- a/assets/collaborative-developement.svg
+++ b/assets/collaborative-developement.svg
@@ -1,4 +1,20 @@
-<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata id="metadata5">
+  <rdf:RDF>
+     <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+          <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title></dc:title>
+          <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+     </cc:Work>
+     <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+     </cc:License>
+  </rdf:RDF>
+</metadata>
 <rect width="595" height="842" fill="white"/>
 <rect width="595" height="842" fill="#FDBBAB"/>
 <rect x="132" y="324" width="200" height="150" fill="black"/>

--- a/assets/unlock.svg
+++ b/assets/unlock.svg
@@ -5,7 +5,7 @@
      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
           <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-          <dc:title></dc:title>
+          <dc:title>Unlock public code</dc:title>
           <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
      </cc:Work>
      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">

--- a/assets/unlock.svg
+++ b/assets/unlock.svg
@@ -1,4 +1,20 @@
-<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata id="metadata5">
+  <rdf:RDF>
+     <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+          <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title></dc:title>
+          <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+     </cc:Work>
+     <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+          <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+     </cc:License>
+  </rdf:RDF>
+</metadata>
 <rect width="595" height="842" fill="white"/>
 <rect width="595" height="842" fill="#5B57CA"/>
 <rect x="268" y="405" width="200" height="150" fill="#FFF500"/>


### PR DESCRIPTION
and encoding tag to pass [w3c validator](http://validator.w3.org). The license will make it clearer when discovering the images individually that they are CC0 and having av w3c valid svg is just good practice.