### PR TITLE
Minor editorial tweaks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,3 +39,4 @@ Individual contributors
 * Bert Spaan
 * David Barberi
 * Paul Keller
+* Sky Bristol

--- a/introduction.md
+++ b/introduction.md
@@ -31,14 +31,14 @@ Current public software production methods have not served public service delive
 In the last decade, public organizations that purchased complete software solutions have sometimes been surprised to discover that they:
 
 * can’t change their software to reflect changing policy or take advantage of new technology
-* don’t have access to their data as it's locked in to systems
+* don’t have access to their data as it's locked into proprietary systems
 * are asked to pay ever increasing license fees
 
 ### Technological sovereignty and democratic accountability
 
 Public institutions, civil servants and residents deserve better.
 
-We believe the software that runs our society can no longer be a black box, ordered from outside companies that keep the underlying logic on which their software operates hidden in proprietary codebases. Instead, governments need technological sovereignty - allowing them to set and control the functioning of public software, just like they are able to set and control policy that is legally formulated in laws. Citizens and civil society actors need this software to be transparent and accountable. The design of software as essential civic infrastructure should honor digital citizens’ rights.
+We believe the software that runs our society can no longer be a black box, controlled by outside companies that keep the underlying logic on which their software operates hidden in proprietary codebases. Instead, governments and the people they serve need technological sovereignty - allowing them to set and control the functioning of public software, just like they are able to set and control policy that is legally formulated in laws. Citizens and civil society actors need this software to be transparent and accountable. The design of software as essential civic infrastructure should honor digital citizens’ rights.
 
 ### Designing truly public software
 
@@ -80,7 +80,7 @@ This pooling of resources lets public administrations give extra attention to ho
 
 Public code offers a better economic model for public organizations as well as for commercial companies. It's an alternative to traditional software procurement, which increases local control and economic opportunity.
 
-Designed from the start to be open, adaptable and with data portability, it can be developed by in-house staff or trusted vendors. Because the code is open, the public administration can change vendor if they need. Open code increases opportunities for public learning and scrutiny, allowing the public administration to procure smaller contracts - thereby making it easier for local small and medium enterprises to bid. Public administrations can use their own software purchasing to stimulate innovation and competition in their local economy.
+Designed from the start to be open, adaptable and with data portability, it can be developed by in-house staff or trusted vendors. Because the code is open, the public administration can change vendors if they need. Open code increases opportunities for public learning and scrutiny, allowing the public administration to procure smaller contracts - thereby making it easier for local small and medium enterprises to bid. Public administrations can use their own software purchasing to stimulate innovation and competition in their local economy.
 
 This can be seen as investment leading to future economic growth - more vendors will be necessary due to growing technology demand.
 
@@ -94,7 +94,7 @@ To use existing public code, you need to specify in your budget and project desi
 
 Our organization ensures that codebases under its stewardship (and not in incubation or the attic) are compliant with the Standard for Public Code. This makes clear to potential users and contributors that the codebase is of high quality, and updates will be too.
 
-The audit performed by our organization is meant to complement machine testing, as machines are great at testing things like syntax and whether outcomes align with expectations. Things meant for humans, such as testing whether documentation is actually understandable and attached, the commit messages make sense and whether community guidelines are being followed are impossible for machines to test against.
+The audit performed by our organization is meant to complement machine testing, as machines are great at testing things like syntax and whether outcomes align with expectations. Things meant for humans, such as testing whether documentation is actually understandable and accessible in context, the commit messages make sense, and whether community guidelines are being followed are impossible for machines to test.
 
 The audit tests the entire codebase, including source code, policy, documentation and conversation for compliance with both the standards set out by our organization and the standards set out in the codebase itself.
 
@@ -110,16 +110,16 @@ The audit is presented as a review of the contribution. The codebase steward giv
 
 For the codebase to be completely certified every meaningful line of code, and the commits behind the code, need to meet the Standard.
 
-If codebases have been completely audited from the first merge request they can be completely be certified as compliant with the Standard for Public Code immediately.
+If codebases have been completely audited from the first merge request they can be immediately certified as compliant with the Standard for Public Code.
 
-If the audit process is added to an existing codebase, the new merge requests can be certified, but the existing code cannot be certified. By auditing every new merge request the codebase can move towards being completely certified.
+If the audit process is added to an existing codebase, the new merge requests can be certified, but the existing code cannot be certified. By auditing every new merge request the codebase can move incrementally towards being completely certified.
 
 ## The goals for the Standard for Public Code
 
 This Standard supports developers, designers, business management and policy makers to:
 
 * develop high quality software and policy for better public service delivery
-* develop reusable codebases that can be reused across contexts and collaboratively maintained
+* develop buildable codebases that can be reused across contexts and collaboratively maintained
 * reduce technical debt and project failure rate
 * have more granular control over, and ability to make decisions about, their IT systems
 * improve vendor relationships with a better economic model

--- a/introduction.md
+++ b/introduction.md
@@ -119,7 +119,7 @@ If the audit process is added to an existing codebase, the new merge requests ca
 This Standard supports developers, designers, business management and policy makers to:
 
 * develop high quality software and policy for better public service delivery
-* develop buildable codebases that can be reused across contexts and collaboratively maintained
+* develop codebases that can be reused across contexts and collaboratively maintained
 * reduce technical debt and project failure rate
 * have more granular control over, and ability to make decisions about, their IT systems
 * improve vendor relationships with a better economic model

--- a/readers-guide.md
+++ b/readers-guide.md
@@ -1,6 +1,6 @@
 # Readers guide
 
-The criteria in the Standard have a consistent sections that together make it clear how to create great public code.
+The criteria in the Standard have consistent sections that together make it clear how to create great public code.
 
 ## Requirements
 
@@ -32,11 +32,11 @@ We've tried to word it so that someone who is not intimately acquainted with the
 
 This section tries to specifically speak to policy makers by offering them concrete actions they can perform in their role.
 
-Policy makers are usually less technologically experienced but often set the priorities and goals of projects.
+Policy makers set the priorities and goals of projects and may be less technologically experienced.
 
 ## Management: what you need to do
 
-This section tries to specifically speak to management by offering them concrete actions they can perform in their role.
+This section tries to specifically speak to management by offering concrete actions they can perform in their role.
 
 Management is responsible for on-time project delivery, stakeholder management and continued delivery of the service. For this they are wholly reliant on both the policy makers as well as the developers and designers. They need to create the right culture, line up the right resources and provide the right structures to deliver great services.
 


### PR DESCRIPTION
I made a few editorial suggestions in the files of the standard as I was reading through (sorry, I couldn't help myself).

I really like what you all are doing with this standard. In my day job, I work in the federal sector in the US as a scientist in a non-regulatory context. My job is to study and provide information on what we observe and understand, but I'm very interested in the process of opening up the policymaking space to direct democratic involvement by the people whose lives are effected by government policies.

I was curious about one thing in your underlying philosophy. You state explicitly in your introduction, "It is not aimed at public organizations’ end users (residents or citizens)." I get where you're coming from to a certain extent, but I'm interested in your thoughts on how public policy software processes that help guide direction in our cities and regions may be contributed to directly by interested citizens. It seems like this is being done in various ways around the world through city hack-a-thons, code challenges, and less structured experiments. You have a great structure to the standard with very clear language targeted at your stated audiences, which I found quite compelling. But I'm curious about why the decision to explicitly not think about the implications to residents or citizens themselves.

-----
[View rendered introduction.md](https://github.com/skybristol/standard/blob/editorial-finds/introduction.md)
[View rendered readers-guide.md](https://github.com/skybristol/standard/blob/editorial-finds/readers-guide.md)