### PR TITLE
Simplify & avoid 'code and docs under "a" licnese'

### DIFF
--- a/criteria/open-licenses.md
+++ b/criteria/open-licenses.md
@@ -6,7 +6,7 @@ order: 12
 
 ## Requirements
 
-* All code and documentation MUST be published under a license that allows it to be freely reusable, changeable and redistributable
+* All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable
 * Software source code MUST be licensed under an [OSI-approved open source license](https://opensource.org/licenses/category)
 * All code MUST be published with a license file
 * All source code files in the codebase SHOULD include a copyright notice and a license header


### PR DESCRIPTION
While it is implied that code and docs are not required to share a
license, the previous wording could be read in such a way as to
suggest that they MUST.

This commit simplifies the language and removes this possible
mis-reading.

-----
[View rendered criteria/open-licenses.md](https://github.com/publiccodenet/standard/blob/simpler-code-doc-license/criteria/open-licenses.md)