### PR TITLE
fixed a typo and removed a forgotten )

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 We understand that a standard like this can only be set in collaboration with as many public technologists, policy makers and interested folk as possible. Thus we appreciate your input, enjoy feedback and welcome improvements to this project and are very open to collaboration.
 
-We love issues and pull requests from everyone. If you're not comfortable with Github, you can email use your feedback at <info@publiccode.net>.
+We love issues and pull requests from everyone. If you're not comfortable with GitHub, you can email use your feedback at <info@publiccode.net>.
 
 ## Problems, suggestions and questions in issues
 
@@ -49,4 +49,3 @@ In fact, feel free to open a PR to add your name to the [`AUTHORS`](AUTHORS.md) 
 ---
 
 For more information on how to use and contribute to this project, please read the [`README`](README.md).
-)


### PR DESCRIPTION
same capitalizing on the entire page

-----
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/standard/blob/github-typo/CONTRIBUTING.md)