### PR TITLE
minor wordsmithing and link added to the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ weasyprint http://localhost:4000/print.html standard.pdf
 
 © [The authors and contributors](AUTHORS.md)
 
-The standard is [licensed](LICENSE.md) CC 0, which also applies to all illustrations and the documentation. This means anyone can do anything with it. If you contribute you also grant these rights to others. You can read more about how to help in the [contributing guide](CONTRIBUTING.md)
+The standard is [licensed](LICENSE.md) under CC 0, which also applies to all illustrations and the documentation. This means anyone can do anything with it. If you contribute you also grant these rights to others. You can read more about how to help in the [contributing guide](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The standard lives at [standard.publiccode.net](https://standard.publiccode.net/
 
 ## Help improve this standard
 
-We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop it. 😊 Get started by reading our [contributors guide](CONTRIBUTING.md). Since it is such a core document we will accept contribution when they add significant value. We've described how we govern the standard in the [governance statement](GOVERNANCE.md).
+We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop it. 😊 Get started by reading our [contributors guide](CONTRIBUTING.md). Since it is such a core document we will accept contributions when they add significant value. We've described how we govern the standard in the [governance statement](GOVERNANCE.md).
 
 Please note that this project is released with a [contributor code of conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Please be lovely to all other community members.
 
@@ -46,9 +46,8 @@ weasyprint http://localhost:4000/print.html standard.pdf
     - [ ] Inside pages PDF
 4. Create GitHub release with the release notes and version number
 
-## license
+## License
 
 © [The authors and contributors](AUTHORS.md)
 
-licensed under the CC-0, including all illustrations and documentation. This means anyone can do anything with it. If you contribute you also grant these rights to others.
-You can read more about how to help in the [contributing guide](CONTRIBUTING.md)
+The standard is [licensed](LICENSE.md) CC 0, which also applies to all illustrations and the documentation. This means anyone can do anything with it. If you contribute you also grant these rights to others. You can read more about how to help in the [contributing guide](CONTRIBUTING.md)


### PR DESCRIPTION
Tried to make the license section more clear

-----
[View rendered README.md](https://github.com/publiccodenet/standard/blob/readme-polish/README.md)