### PR TITLE
Minor phrasing changes in introduction and criteria pages

### DIFF
--- a/criteria/code-in-the-open.md
+++ b/criteria/code-in-the-open.md
@@ -29,7 +29,7 @@ Coding in the open:
 The source for any version currently in use is published on the internet where it can be seen:
 
 * from outside the original contributing organization,
-* without the need for any form of authentication.
+* without the need for any form of authentication or authorization.
 
 ## Policy makers: what you need to do
 

--- a/criteria/open-standards.md
+++ b/criteria/open-standards.md
@@ -10,7 +10,7 @@ order: 10
 * If no existing open standard is available, effort SHOULD be put into developing one.
 * Standards that are machine testable SHOULD be preferred over those that are not.
 * Functionality using features from a non-open standard (one that doesn't meet the [Open Source Initiative Open Standard Requirements](https://opensource.org/osr)) MAY be provided if necessary, but only in addition to compliant features.
-* All non-compliant standards used MUST be documented clearly in the documentation.
+* All non-compliant standards used MUST be recorded clearly in the documentation.
 * The codebase SHOULD contain a list of all the standards used with links to where they are available.
 
 ## Why this is important

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -39,7 +39,7 @@ order: 9
 ## Management: what you need to do
 
 * Try to limit the use of acronyms, abbreviations, puns or legal/domain specific terms in internal communications in and between teams and stakeholders.
-* Be critical of documentation and descriptions in proposals and changes - if you don't understand something, others will probably others also not.
+* Be critical of documentation and descriptions in proposals and changes - if you don't understand something, others will probably also struggle with it.
 
 ## Developers and designers: what you need to do
 

--- a/glossary.md
+++ b/glossary.md
@@ -14,7 +14,7 @@ This can be – for example – a document or a version-control repository.
 
 The public at large: end users of the code and the services based upon it.
 
-For example, the end users of both a service provided by a city and the code that runs the service are the city's residents.
+For example, a city's residents are considered end users of a city's services and of all code that powers these services.
 
 ## Open source
 

--- a/introduction.md
+++ b/introduction.md
@@ -78,9 +78,9 @@ This pooling of resources lets public administrations give extra attention to ho
 
 ### Economics of public code
 
-Public code offers a better economic model for public organizations as well as for commercial companies. It's an alternative to traditional software procurement, which increases local control and economic opportunity.
+Public code offers a better economic model for public organizations as well as for commercial companies. It's an alternative to traditional software procurement which increases local control and economic opportunity.
 
-Designed from the start to be open, adaptable and with data portability, it can be developed by in-house staff or trusted vendors. Because the code is open, the public administration can change vendors if they need. Open code increases opportunities for public learning and scrutiny, allowing the public administration to procure smaller contracts - thereby making it easier for local small and medium enterprises to bid. Public administrations can use their own software purchasing to stimulate innovation and competition in their local economy.
+Designed from the start to be open, adaptable and with data portability, it can be developed by in-house staff or trusted vendors. Because the code is open, the public administration can change vendors if they need to. Open code increases opportunities for public learning and scrutiny, allowing the public administration to procure smaller contracts - thereby making it easier for local small and medium enterprises to bid. Public administrations can use their own software purchasing to stimulate innovation and competition in their local economy.
 
 This can be seen as investment leading to future economic growth - more vendors will be necessary due to growing technology demand.
 
@@ -100,7 +100,7 @@ The audit tests the entire codebase, including source code, policy, documentatio
 
 ### How the process works
 
-Every time a contribution is suggested to a codebase – through for instance a merge request – the [codebase stewards](https://about.publiccode.net/roles/) of our organization will audit the contribution for compliance with the Standard for Public Code. New contributions can only be adopted into the codebase after they have been approved as compliant with the Standard for Public Code, as well as being reviewed by another contributor.
+Every time a contribution is suggested to a codebase – through for instance a merge request – the [codebase stewards](https://about.publiccode.net/roles/) of our organization will audit the contribution for compliance with the Standard for Public Code. New contributions can only be adopted into the codebase after they have been approved as compliant with the Standard for Public Code, and have been reviewed by another contributor.
 
 The audit is presented as a review of the contribution. The codebase steward gives line by line feedback and compliance, helping the contributor to improve their contribution. The merge request cannot be fulfilled until the codebase stewards have approved the contribution.
 
@@ -126,7 +126,7 @@ This Standard supports developers, designers, business management and policy mak
 
 [We help public organizations](https://publiccode.net/) share and adopt open source software, build sustainable developer communities and create a thriving ecosystem for public code. It does this through codebase stewardship. For this process the codebase stewards use the Standard for Public Code to make sure the code it stewards is high quality as well as collaboratively maintainable.
 
-Potential users of codebases tested against the Standard for Public Code can expect them to be highly reusable, easily maintainable and high quality.
+Potential users of codebases tested against the Standard for Public Code can expect them to be highly reusable, easily maintainable and of high quality.
 
 The Standard for Public Code does this by:
 


### PR DESCRIPTION
These changes aim to clarify a few phrases that I found fuzzy while reading the standard.

Does it make sense to add links to rendered views of the changed files here?