### PR TITLE
split into two lines, workaround for mashed links

### DIFF
--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -28,7 +28,8 @@ order: 9
 
 * Check that translations and the English version have the same content.
 * Validate that no unexplained acronyms, abbreviations, puns or legal/domain specific terms are in the documentation.
-* Test the documentation using [Grammarly](https://www.grammarly.com/) or [Hemingway text editor](https://hemingwayapp.com/).
+* Test the documentation for grammar using [Grammarly](https://www.grammarly.com/).
+* Test the documentation for readability [Hemingway text editor](https://hemingwayapp.com/).
 * Ask someone outside of your context if they understand your content (for example, a developer working on a different project).
 
 


### PR DESCRIPTION
since the two links render in the same place with the print css, this is a workaround until (or if) we can fix it in the css

-----
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/untangle-links/criteria/understandable-english-first.md)