### PR TITLE
adding for Public Code

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 This standard lies at the core of the codebase stewardship provided by the [Foundation for Public Code](https://publiccode.net/). It is the document on the basis of which we decide that a codebase is ready for community co-development.
 
-The standard is maintained by Foundation staff.
+The standard is maintained by Foundation for Public Code staff.
 
 [We welcome contributions – such as suggestions for changes or general feedback – from anyone.](/CONTRIBUTING.md)
 


### PR DESCRIPTION
According to [our branding](https://brand.publiccode.net/name/), not referring to ourselves as just the Foundation.

-----
[View rendered GOVERNANCE.md](https://github.com/publiccodenet/standard/blob/foundation-words/GOVERNANCE.md)