### PR TITLE
Issue #57, "your codebase" -> "the codebase"

### DIFF
--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -17,7 +17,7 @@ order: 11
 ## Why this is important
 
 * Using continuous integration:
-  * allows you to quickly identify problems with your codebase,
+  * allows you to quickly identify problems with the codebase,
   * enable risk taking and focusing on problem solving while minimising stress on the contributors,
   * lowers barriers for new contributors by reducing the amount of understanding necessary to suggest changes,
   * leads to more maintainable code,

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -20,7 +20,7 @@ Clearly signalling a codebase's maturity helps others to decide whether to reuse
 
 ## What this does not do
 
-* Guarantee that others will use your code.
+* Guarantee that others will use the code.
 
 ## How to test
 

--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -20,7 +20,7 @@ Documenting your objectives:
 ## What this does not do
 
 * Guarantee that the codebase achieves the stated objective(s).
-* Guarantee contributions to your codebase.
+* Guarantee contributions to the codebase.
 * Prevent other codebases from attempting to achieve the same objectives.
 
 ## How to test

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -1,26 +1,26 @@
 ---
 order: 8
 ---
-# Document your code
+# Document the code
 
 ## Requirements
 
-* All of the functionality of your codebase – policy as well as source – MUST be described in language clearly understandable for those that understand the purpose of the code.
-* The documentation of your codebase MUST contain:
+* All of the functionality of the codebase – policy as well as source – MUST be described in language clearly understandable for those that understand the purpose of the code.
+* The documentation of the codebase MUST contain:
   * a description of how to install and run the source code,
   * examples demonstrating the key functionality.
-* The documentation of your codebase SHOULD contain:
+* The documentation of the codebase SHOULD contain:
   * a high level description that is clearly understandable for a wide audience of stakeholders, like the general public and journalists,
   * a section describing how to install and run a standalone version of the source code, including, if necessary, a test dataset,
   * examples for all functionality.
 * There SHOULD be continuous integration tests for the quality of your documentation.
-* The documentation of your codebase MAY contain examples that make users want to immediately start using your codebase.
-* You MAY use the examples in your documentation to test your code.
+* The documentation of the codebase MAY contain examples that make users want to immediately start using the codebase.
+* You MAY use the examples in your documentation to test the code.
 
 ## Why this is important
 
 * Users can start using and contributing more quickly.
-* You help people discover your codebase, especially people asking 'is there already code that does something like this'.
+* You help people discover the codebase, especially people asking 'is there already code that does something like this'.
 * This provides transparency into your organization and processes.
 
 ## What this does not do

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -29,7 +29,7 @@ order: 3
 
 ## How to test
 
-* Ask someone in a similar role at another organization if they could reuse your codebase and what that would entail.
+* Ask someone in a similar role at another organization if they could reuse the codebase and what that would entail.
 * Codebase is in use by multiple parties or in multiple contexts.
 
 ## Policy makers: what you need to do

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -15,13 +15,13 @@ order: 9
 
 ## Why this is important
 
-* Makes your codebase and what it does understandable for a wider variety of stakeholders in multiple contexts.
-* Helps with the discoverability of your codebase.
+* Makes the codebase and what it does understandable for a wider variety of stakeholders in multiple contexts.
+* Helps with the discoverability of the codebase.
 * Can help you meet the [European Union accessibility directive](https://ec.europa.eu/digital-single-market/en/web-accessibility), which requires most public sector information to be accessible
 
 ## What this does not do
 
-* Make explanations of your codebase's functionality understandable.
+* Make explanations of the codebase's functionality understandable.
 * Make your organization's jargon understandable without an explanation.
 
 ## How to test

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -6,17 +6,17 @@ order: 5
 
 ## Requirements
 
-* You MUST have a way to maintain version control for your code.
+* You MUST have a way to maintain version control for the code.
 * All files in a codebase MUST be version controlled.
 * All decisions MUST be documented in commit messages.
 * Every commit message MUST link to discussions and issues wherever possible.
 * You SHOULD group relevant changes in commits.
-* You SHOULD mark different versions of your codebase, for example using revision tags or textual labels.
+* You SHOULD mark different versions of the codebase, for example using revision tags or textual labels.
 * You SHOULD prefer file formats that can easily be version controlled.
 
 ## Why this is important
 
-Version control means keeping track of changes to your code over time. This allows you to create structured documentation of the history of the codebase. This is essential for collaboration at scale.
+Version control means keeping track of changes to the code over time. This allows you to create structured documentation of the history of the codebase. This is essential for collaboration at scale.
 
 Version control enables you to:
 
@@ -28,7 +28,7 @@ Version control enables you to:
 ## What this does not do
 
 * Substitute for [advertising maturity](document-maturity.md).
-* Guarantee your code executes correctly.
+* Guarantee the code executes correctly.
 * Guarantee collaborators.
 
 ## How to test

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ The Standard for Public Code gives cities a model for building their own open so
   * [Maintain version control](criteria/version-control-and-history.md)
   * [Require review of contributions](criteria/require-review.md)
   * [Document your objectives](criteria/document-objectives.md)
-  * [Document your code](criteria/documenting.md)
+  * [Document the code](criteria/documenting.md)
   * [Use plain English](criteria/understandable-english-first.md)
   * [Use open standards](criteria/open-standards.md)
   * [Use continuous integration](criteria/continuous-integration.md)


### PR DESCRIPTION
The possesive "your contribution" is appropriate.
For codebases which are Public Code, we should use "the codebase" or
perhaps in some cases one might use "our codebase" but not "your codebase"
becuase the codebase is a shared resource.

-----
[View rendered criteria/advertise-maturity.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/advertise-maturity.md)
[View rendered criteria/continuous-integration.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/continuous-integration.md)
[View rendered criteria/document-objectives.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/document-objectives.md)
[View rendered criteria/documenting.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/documenting.md)
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/reusable-and-portable-codebases.md)
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/understandable-english-first.md)
[View rendered criteria/version-control-and-history.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/criteria/version-control-and-history.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/eh-issue-57-style/index.md)