### PR TITLE
Change "Pay attention to" to "Document"

### DIFF
--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -1,7 +1,7 @@
 ---
 order: 14
 ---
-# Pay attention to codebase maturity
+# Document codebase maturity
 
 ## Requirements
 

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -27,7 +27,7 @@ Version control enables you to:
 
 ## What this does not do
 
-* Substitute for [advertising maturity](advertise-maturity.md).
+* Substitute for [advertising maturity](document-maturity.md).
 * Guarantee your code executes correctly.
 * Guarantee collaborators.
 

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ The Standard for Public Code gives cities a model for building their own open so
   * [Use continuous integration](criteria/continuous-integration.md)
   * [Publish with an open license](criteria/open-licenses.md)
   * [Use a coherent style](criteria/style.md)
-  * [Pay attention to codebase maturity](criteria/advertise-maturity.md)
+  * [Document codebase maturity](criteria/document-maturity.md)
 * [Authors](AUTHORS.md)
 * [Contributing guide](CONTRIBUTING.md)
 * [Code of conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Addresses Issue #58 and Issue #137
https://github.com/publiccodenet/standard/issues/58
https://github.com/publiccodenet/standard/issues/137

The phrase "pay attention to" is too vague relative to the criteria.
The phrase "document" is perhaps too narrow given the criteria.
Thus this is only a small improvement; perhaps better wording will
be contributed in the near future.

-----
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/eh-issue-58-maturity/criteria/document-maturity.md)
[View rendered criteria/version-control-and-history.md](https://github.com/publiccodenet/standard/blob/eh-issue-58-maturity/criteria/version-control-and-history.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/eh-issue-58-maturity/index.md)