### PR TITLE
Issue #38, "civic code" -> "civil code"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -26,7 +26,7 @@ An open standard is any standard that meets the Open Source Initiative's [Open S
 
 ## Public code
 
-Public code is both civic code (like policy or regulation) and computer source code (such as software and algorithms) executed in a public context, by humans or machines.
+Public code is both civil code (like policy or regulation) and computer source code (such as software and algorithms) executed in a public context, by humans or machines.
 
 Because public code serves the public interest, it should be open, legible, accountable, accessible and sustainable.
 


### PR DESCRIPTION
https://github.com/publiccodenet/standard/issues/38

Use the more appropriate term "civil code" rather than "civic code"
in the glossary.

-----
[View rendered glossary.md](https://github.com/publiccodenet/standard/blob/eh-issue-38-civic-civil/glossary.md)