### PR TITLE
Added section "Further reading" to Introduction

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -151,6 +151,9 @@ These people work at:
 
 It is not aimed at public organizations' end users (residents or citizens), journalists or academics.
 
+## Further reading
+- Whitepaper about public code titled: ["Modernising Public Infrastructure with Free Software"](https://download.fsfe.org/campaigns/pmpc/PMPC-Modernising-with-Free-Software.pdf)
+
 ## Get involved
 
 This standard is a living document. [Read our contributor guide](/CONTRIBUTING.md) to learn how you can make it better.


### PR DESCRIPTION
It would be nice to include a few introduction links about the underlying issue of public code for further reading for people new to the subject / issue. I've added one link which is a nice whitepaper from the Free Software Foundation Europe which describe the issue of public code in great detail including interviews and case studies of public organisations working with open source/ free software explaining the value and benefits of public code.

-----
[View rendered introduction.md](https://github.com/publiccodenet/standard/blob/felixfaassen-introduction-further-reading/introduction.md)