### PR TITLE
Changed readers guide to clarify cirteria-section relation

### DIFF
--- a/readers-guide.md
+++ b/readers-guide.md
@@ -1,6 +1,7 @@
 # Readers guide
 
-The criteria in the Standard have consistent sections that together make it clear how to create great public code.
+The Standard describes a number of criteria. Each criteria have consistent sections that make it clear how to create great public code. 
+Below is a brief explination of each of these sections and how they are used within the criteria of the Standard.
 
 ## Requirements
 

--- a/readers-guide.md
+++ b/readers-guide.md
@@ -1,7 +1,7 @@
 # Readers guide
 
 The Standard describes a number of criteria. Each criteria have consistent sections that make it clear how to create great public code. 
-Below is a brief explination of each of these sections and how they are used within the criteria of the Standard.
+Below is a brief explanation of each of these sections and how they are used within the criteria of the Standard.
 
 ## Requirements
 


### PR DESCRIPTION
When reading the standard for the first time it might yet not be clear how the information is structured. (my first read I thought "what criteria?)  By slightly rewriting this we can introduce the reader to the taxonomy of the standard (standard has ->criteria->section), each criteria has consistent sections which will briefly explain in this introduction.

-----
[View rendered readers-guide.md](https://github.com/publiccodenet/standard/blob/felixfaassen-reader-guide-criteria-relation/readers-guide.md)