### PR TITLE
Add new terms and footnote section to glossary.md

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -12,7 +12,7 @@ This can be – for example – a document or a version-control repository.
 
 ## Continous Integration
 
-Continous Integration: In software engineering, continuous integration (CI) is the practice of merging all developers' working copies to a shared mainline of a codebase several times a day.<sup>[1](#footnote1)</sup>
+Continous Integration: In software engineering, continuous integration (CI) is the practice of merging all developers' working copies to a development branch of a codebase as frequently as reasonable. 
 
 ## General public
 
@@ -44,13 +44,8 @@ To facilitate re-use, public code should be either released into the public doma
 
 ## Repository
 
-In revision (or version) control systems, a repository<sup>[2](#footnote2)</sup> is a data structure which stores metadata for a set of files or directory structure. 
+In revision (or version) control systems, a repository is a data structure which stores metadata for a set of files or directory structure. (source: SVNBook)
 
 ## Version control
 
-A component of software configuration management, version control, also known as revision control or source control,<sup>[3](#footnote3)</sup>is the management of changes to documents, computer programs, large web sites, and other collections of information. Changes are usually identified by a number or letter code, termed the "revision number", "revision level", or simply "revision". For example, an initial set of files is "revision 1". When the first change is made, the resulting set is "revision 2", and so on. Each revision is associated with a timestamp and the person making the change. Revisions can be compared, restored, and with some types of files, merged.
-
-### Footnotes
-- <a name="footnote1">1</a>: O'Sullivan, Bryan (2009). Mercurial: the Definitive Guide. Sebastopol: O'Reilly Media, Inc. ISBN 9780596555474. Retrieved from Wikipedia 8 May 2020.
-- <a name="footnote2">2</a>: SVNBook.
-- <a name="footnote3">3</a>: Fowler, Martin (1 May 2006). "Continuous Integration". martinfowler.com. Retrieved 9 January 2014.
+A component of software configuration management, version control, also known as revision control or source control, is the management of changes to documents, computer programs, large web sites, and other collections of information. Changes are usually identified by a number or letter code, termed the "revision number", "revision level", or simply "revision". For example, an initial set of files is "revision 1". When the first change is made, the resulting set is "revision 2", and so on. Each revision is associated with a timestamp and the person making the change. Revisions can be compared, restored, and with some types of files, merged. (source: Fowler, Martin (1 May 2006). "Continuous Integration". martinfowler.com. Retrieved 9 January 2014.)

--- a/glossary.md
+++ b/glossary.md
@@ -10,6 +10,10 @@ Any discrete package of code (both source and policy), the tests and the documen
 
 This can be – for example – a document or a version-control repository.
 
+## Continous Integration
+
+Continous Integration: In software engineering, continuous integration (CI) is the practice of merging all developers' working copies to a shared mainline of a codebase several times a day.<sup>[1](#footnote1)</sup>
+
 ## General public
 
 The public at large: end users of the code and the services based upon it.
@@ -37,3 +41,16 @@ By developing public code independently from but still implementable in the loca
 * use as a basis for learning
 
 To facilitate re-use, public code should be either released into the public domain or licensed with an open license that permits others to view and reuse the work freely and to produce derivative works.
+
+## Repository
+
+In revision (or version) control systems, a repository<sup>[2](#footnote2)</sup> is a data structure which stores metadata for a set of files or directory structure. 
+
+## Version control
+
+A component of software configuration management, version control, also known as revision control or source control,<sup>[3](#footnote3)</sup>is the management of changes to documents, computer programs, large web sites, and other collections of information. Changes are usually identified by a number or letter code, termed the "revision number", "revision level", or simply "revision". For example, an initial set of files is "revision 1". When the first change is made, the resulting set is "revision 2", and so on. Each revision is associated with a timestamp and the person making the change. Revisions can be compared, restored, and with some types of files, merged.
+
+### Footnotes
+- <a name="footnote1">1</a>: O'Sullivan, Bryan (2009). Mercurial: the Definitive Guide. Sebastopol: O'Reilly Media, Inc. ISBN 9780596555474. Retrieved from Wikipedia 8 May 2020.
+- <a name="footnote2">2</a>: SVNBook.
+- <a name="footnote3">3</a>: Fowler, Martin (1 May 2006). "Continuous Integration". martinfowler.com. Retrieved 9 January 2014.


### PR DESCRIPTION
I've added 3 terms which are used in the standard but where not on the glossary:

Version Control / Repository / Continuous Integration. Please feel free to rewrite as in software engineering the definition of these terms is much debated (like continuous integration for example)

I also added a footnote section to be able to reference to the original source material of the definition. Git Markdown does not support footnotes so I used the HTML anchors however I can imagine this way of handling footnotes is far from ideal (not "pure" markdown, and numbering issues) I will create a separate issue for handling footnotes to refer to original source material when re-using text or definitions from other material.

-----
[View rendered glossary.md](https://github.com/publiccodenet/standard/blob/felixfaassen-glossary-added-terms/glossary.md)