### PR TITLE
FIXED: Link to portable code criteria

### DIFF
--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -25,7 +25,7 @@ order: 8
 
 ## What this does not do
 
-* Contribute directly to more reusable, portable code (see [Code in the open](./code-in-the-open.md)).
+* Contribute directly to more reusable, portable code (see [Create reusable and portable code](./reusable-and-portable-codebases.md)).
 
 ## How to test
 


### PR DESCRIPTION
In the "What this does not do section" we are referring to the portable and reusable criteria in the text but linking to the code in the open  criteria.

-----
[View rendered criteria/documenting.md](https://github.com/publiccodenet/standard/blob/felixfaassen-link-to-portable-code-criteria/criteria/documenting.md)