### PR TITLE
Split requirement into brief example & test

### DIFF
--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -12,7 +12,7 @@ order: 3
 * The roadmap SHOULD be influenced by the needs of multiple parties.
 * Code SHOULD be general purpose and SHOULD be configurable.
 * Codebases SHOULD include a [publiccode.yml](https://github.com/italia/publiccode.yml) metadata description so that they're easily discoverable.
-* Code and its documentation SHOULD NOT contain situation-specific information such as hostnames.
+* Code and its documentation SHOULD NOT contain situation-specific information.
 
 ## Why this is important
 

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -20,6 +20,7 @@ order: 3
 * Makes the code easier for new people to understand (as it's more general).
 * Makes it easier to control the mission, vision and scope of the codebase because the codebase is thoughtfully and purposefully designed for reusability.
 * Codebases used by multiple parties have broad enough value to be Public Code and are more likely to benefit from a self-sustaining community.
+* Any contributor is able to test and contribute without relying on the situation-specific infrastructure of any other contributor or deployment.
 
 ## What this does not do
 
@@ -31,7 +32,7 @@ order: 3
 
 * Ask someone in a similar role at another organization if they could reuse the codebase and what that would entail.
 * Codebase is in use by multiple parties or in multiple contexts.
-* Check that no personal or organizational data, tokens, or passwords used in production systems are included in the codebase or documentation.
+* For each commit, reviewers verify that content does not include situation-specific data such as hostnames, personal and organizational data, or tokens and passwords.
 
 ## Policy makers: what you need to do
 

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -12,7 +12,7 @@ order: 3
 * The roadmap SHOULD be influenced by the needs of multiple parties.
 * Code SHOULD be general purpose and SHOULD be configurable.
 * Codebases SHOULD include a [publiccode.yml](https://github.com/italia/publiccode.yml) metadata description so that they're easily discoverable.
-* Code and its documentation SHOULD not contain situation-specific information. For example, personal and organizational data as well as tokens and passwords used in the production system should never be included.
+* Code and its documentation SHOULD NOT contain situation-specific information such as hostnames.
 
 ## Why this is important
 
@@ -31,6 +31,7 @@ order: 3
 
 * Ask someone in a similar role at another organization if they could reuse the codebase and what that would entail.
 * Codebase is in use by multiple parties or in multiple contexts.
+* Check that no personal or organizational data, tokens, or passwords used in production systems are included in the codebase or documentation.
 
 ## Policy makers: what you need to do
 


### PR DESCRIPTION
I noticed that "SHOULD not" would be better as "SHOULD NOT" but
then realized that the requirement could be made sharper, and
some of the extra verbosity moved to the "How to test" section

-----
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/eh-requirement-examples-as-test/criteria/reusable-and-portable-codebases.md)