### PR TITLE
Add the author with the link to PCMC whitepaper

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -152,7 +152,7 @@ These people work at:
 It is not aimed at public organizations' end users (residents or citizens), journalists or academics.
 
 ## Further reading
-- Whitepaper about public code titled: ["Modernising Public Infrastructure with Free Software"](https://download.fsfe.org/campaigns/pmpc/PMPC-Modernising-with-Free-Software.pdf)
+- ["Modernising Public Infrastructure with Free Software" whitepaper](https://download.fsfe.org/campaigns/pmpc/PMPC-Modernising-with-Free-Software.pdf) by the Free Software Foundation Europe
 
 ## Get involved
 


### PR DESCRIPTION
Since the Public Money? Public Code! whitepaper from the Free Software Foundation Europe contains some strong language urging for policy change (which we cannot do since we're non-partisan and charitable), and people could be confused in thinking we're behind it due to similar language use, I believe we should clearly indicate who the publisher is. 

The style is now in line with the rest of the criteria.

-----
[View rendered introduction.md](https://github.com/publiccodenet/standard/blob/author-whitepaper/introduction.md)