### PR TITLE
Split Welcome contributions into two criteria

### DIFF
--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 ---
 
 # Use continuous integration

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 15
 ---
 # Document codebase maturity
 

--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 8
 ---
 
 # Document your objectives

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -1,5 +1,5 @@
 ---
-order: 8
+order: 9
 ---
 # Document the code
 

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -1,0 +1,48 @@
+---
+order: 5
+---
+
+# Make contributing easy
+
+## Requirements
+
+* The codebase MUST have a public issue tracker that accepts suggestions from anyone.
+* The codebase MUST include an email address for security issues and responsible disclosure.
+* The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a README file.
+* The project MUST have communication channels for users and developers, for example email lists.
+* The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.
+
+## Why this is important
+
+* Enables users to fix problems and add features to the shared codebase leading to better, more reliable and feature rich software.
+* Allows collaborative uptake of shared digital infrastructure.
+* Helps users decide to use one codebase over another.
+
+## What this does not do
+
+* Guarantee others will reuse the codebase.
+
+## How to test
+
+* There's a public issue tracker.
+* It's possible to participate in a discussion with other users about the software.
+
+## Policy makers: what you need to do
+
+* Track policy issues in the codebase, so that a relevant external policy expert can volunteer help.
+
+## Management: what you need to do
+
+* Track management issues in the codebase, so that external managers with relevant experience can volunteer help.
+* Support your experienced policy makers, developers and designers to keep contributing to the codebase for as long as possible.
+
+## Developers and designers: what you need to do
+
+* Respond promptly to requests.
+* Keep your management informed of the time and resources you require to support other contributors.
+
+## Further reading
+
+* [The benefits of coding in the open](https://gds.blog.gov.uk/2017/09/04/the-benefits-of-coding-in-the-open/) by the UK Government Digital Service.
+* [Verdaccio's security policy](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md) is a really nice example.
+

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -8,7 +8,7 @@ order: 5
 
 * The codebase MUST have a public issue tracker that accepts suggestions from anyone.
 * The codebase MUST include an email address for security issues and responsible disclosure.
-* The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a README file.
+* The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
 * The project MUST have communication channels for users and developers, for example email lists.
 * The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.
 

--- a/criteria/open-licenses.md
+++ b/criteria/open-licenses.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 ---
 
 # Publish with an open license

--- a/criteria/open-standards.md
+++ b/criteria/open-standards.md
@@ -1,5 +1,5 @@
 ---
-order: 10
+order: 11
 ---
 
 # Use open standards

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -7,9 +7,9 @@ order: 4
 ## Requirements
 
 * The codebase MUST allow anyone to submit suggestions for changes to the codebase.
-* The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a CONTRIBUTING file.
+* The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a `CONTRIBUTING` file.
 * The codebase SHOULD advertize the committed engagement of involved organizations in the development and maintenance.
-* The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a GOVERNANCE file.
+* The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase SHOULD have a publicly available roadmap.
 * The codebase MAY include a code of conduct for contributors.
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -2,51 +2,43 @@
 order: 4
 ---
 
-# Welcome contributions
+# Welcome contributors
 
 ## Requirements
 
-* The codebase MUST have a public issue tracker that accepts suggestions from anyone.
 * The codebase MUST allow anyone to submit suggestions for changes to the codebase.
-* The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
-* The codebase MUST include an email address for security issues and responsible disclosure.
-* The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a `CONTRIBUTING` file.
-* The project MUST have communication channels for users and developers, for example email lists.
+* The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a CONTRIBUTING file.
+* The codebase SHOULD advertize the committed engagement of involved organizations in the development and maintenance.
+* The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a GOVERNANCE file.
 * The codebase SHOULD have a publicly available roadmap.
-* The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
-* The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.
-* The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase MAY include a code of conduct for contributors.
 
 ## Why this is important
 
-* Allows collaborative uptake of shared digital infrastructure.
-* Prevents forks of codebases, in which a community that works on a project splits because there is no shared progress.
+* Helps newcomers understand and trust your codebase community's leadership.
+* Prevents the community that works on a project splitting because there is no way to influence codebase goals and progress - resulting in diverging communities.
 * Helps users decide to use one codebase over another.
-* Enables users to fix problems and add features to the shared codebase leading to better, more reliable and feature rich software.
 
 ## What this does not do
 
+* Guarantee others will join the community.
 * Guarantee others will reuse the codebase.
 
 ## How to test
 
-* There's a public issue tracker.
 * It's possible to submit suggestions for changes to the codebase.
-* It's possible to participate in a discussion with other users about the software.
 * There are contribution guidelines.
+* Codebase governance is clearly explained, including how to influence codebase governance.
 
 ## Policy makers: what you need to do
 
 * Add a list to the codebase of any other resources that policy experts, non-governmental organizations and academics would find useful for understanding or reusing your policy.
-* Track policy issues in the codebase, so that a relevant external policy expert can volunteer help.
 * Consider adding contact details so that other policy makers considering reuse can ask you for advice.
 
 ## Management: what you need to do
 
-* Make sure the documentation explains how your organization is involved in the project, what resources it has available for it and for how long
-* Track management issues in the codebase, so that external managers with relevant experience can volunteer help.
-* Support your experienced policy makers, developers and designers to keep contributing to the codebase for as long as possible.
+* Make sure the documentation explains how your organization is involved in the project, what resources it has available for it and for how long.
+* Support your experienced policy makers, developers and designers to stay part of the community for as long as possible.
 
 ## Developers and designers: what you need to do
 
@@ -58,6 +50,5 @@ order: 4
 * [Building welcoming communities](https://opensource.guide/building-community/) by Open Source Guides.
 * The [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct) is a model code of conduct.
 * [Leadership and governance](https://opensource.guide/leadership-and-governance/) for growing open source community projects, by Open Source Guides.
-* [The benefits of coding in the open](https://gds.blog.gov.uk/2017/09/04/the-benefits-of-coding-in-the-open/) by the UK Government Digital Service.
 * [Building online communities](http://hintjens.com/blog:117) by Pieter Hintjens (long read!).
-* [Verdaccio's security policy](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md) is a really nice example.
+

--- a/criteria/require-review.md
+++ b/criteria/require-review.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 7
 ---
 
 # Require review of contributions

--- a/criteria/style.md
+++ b/criteria/style.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 ---
 
 # Use a coherent style

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -1,5 +1,5 @@
 ---
-order: 9
+order: 10
 ---
 
 # Use plain English

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 ---
 
 # Maintain version control


### PR DESCRIPTION
Partly solves #343 and was discussed in the community call July 2.

-----
[View rendered criteria/continuous-integration.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/continuous-integration.md)
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/document-maturity.md)
[View rendered criteria/document-objectives.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/document-objectives.md)
[View rendered criteria/documenting.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/documenting.md)
[View rendered criteria/make-contributing-easy.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/make-contributing-easy.md)
[View rendered criteria/open-licenses.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/open-licenses.md)
[View rendered criteria/open-standards.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/open-standards.md)
[View rendered criteria/open-to-contributions.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/open-to-contributions.md)
[View rendered criteria/require-review.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/require-review.md)
[View rendered criteria/style.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/style.md)
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/understandable-english-first.md)
[View rendered criteria/version-control-and-history.md](https://github.com/publiccodenet/standard/blob/split-welcome-contributions/criteria/version-control-and-history.md)