### PR TITLE
Add Markdown linting to script/test.sh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer'
+gem 'mdl'

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
+# Lint markdown using the Markdownlint gem with the default ruleset except for:
+# MD007 Unordered list indentation: we allow sub-lists to also have bullets
+# MD013 Line length: we allow long lines
+# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
+#
+# Additionally, we have these violations which should be resolved:
+# MD004 Unordered list style
+# MD009 Trailing spaces
+# MD012 Multiple consecutive blank lines
+# MD022 Headers should be surrounded by blank lines
+# MD026 Trailing punctuation in header
+# MD032 Lists should be surrounded by blank lines
+# MD034 Bare URL used
+#
+bundle exec mdl -r ~MD007,~MD013,~MD029,~MD004,~MD009,~MD012,~MD022,~MD026,~MD032,~MD034 -i -g '.'
+
 # Build the site
 bundle exec jekyll build
 


### PR DESCRIPTION
The develop branch currently contains many linting errors,
we should examine and resolve those one-by-one and remove them
from the exceptions list.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>