### PR TITLE
Add the title to the title page

### DIFF
--- a/print.html
+++ b/print.html
@@ -105,6 +105,13 @@
       clear: both;
     }
 
+    h1.title {
+      font-size: 6em;
+      font-weight: 700;
+      margin-top: 3em;
+      margin-bottom: 1em;
+    }
+
     .markdown-body h2[id$="policy-makers-what-you-need-to-do"]:before,
     .markdown-body h2[id$="management-what-you-need-to-do"]:before,
     .markdown-body h2[id$="developers-and-designers-what-you-need-to-do"]:before {
@@ -218,6 +225,8 @@
 <body class="markdown-body">
 
   <article id="section-first-page">
+    <h1 class="title">Standard for Public Code</h1>
+
     <p>Version {{ site.version }}</p>
     <p>Request for contributions</p>
     <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0"></p>


### PR DESCRIPTION
As it stands we need to generate a separate cover for the PDF.
This change adds the title to the title page.
This means the generated PDF can be used without requiring manual generation.

![image](https://user-images.githubusercontent.com/1917629/97284970-f65a8380-1841-11eb-9c5c-94769ac7383c.png)
