### PR TITLE
Add redirect for criteria/advertise-maturity

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
 title: Standard for Public Code
 version: 0.2.0
 
+plugins:
+  - jekyll-redirect-from
+
 remote_theme: publiccodenet/jekyll-theme
 include:
   - "README.md"

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -1,5 +1,7 @@
 ---
 order: 15
+redirect_from:
+    - criteria/advertise-maturity
 ---
 # Document codebase maturity
 


### PR DESCRIPTION
The criterion for codebase maturity was renamed and the URL changed,
yet the contents are essentially the same, thus we redirect.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

Issue #407

-----
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/release-2.0-hotfix/criteria/document-maturity.md)