### PR TITLE
Harmonize use of codebase vs project

### DIFF
--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -23,7 +23,7 @@ order: 12
   * leads to more maintainable code,
   * speeds up the development cycle.
 * Smaller more regular contributions are typically easier to evaluate and lower risk compared to large infrequent changes.
-* Projects in active development more reliably provide opportunities for collaboration and feedback.
+* Codebases in active development more reliably provide opportunities for collaboration and feedback.
 
 ## What this does not do
 

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -16,7 +16,7 @@ order: 15
 
 ## Why this is important
 
-Clearly signalling a codebase's maturity helps others decide whether to reuse, invest in or contribute to the project.
+Clearly signalling a codebase's maturity helps others decide whether to reuse, invest in or contribute to it.
 
 ## What this does not do
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -16,7 +16,7 @@ order: 4
 ## Why this is important
 
 * Helps newcomers understand and trust your codebase community's leadership.
-* Prevents the community that works on a project splitting because there is no way to influence codebase goals and progress – resulting in diverging communities.
+* Prevents the community that works on a codebase splitting because there is no way to influence its goals and progress – resulting in diverging communities.
 * Helps users decide to use one codebase over another.
 
 ## What this does not do
@@ -37,7 +37,7 @@ order: 4
 
 ## Management: what you need to do
 
-* Make sure the documentation explains how your organization is involved in the project, what resources it has available for it and for how long.
+* Make sure the documentation explains how your organization is involved in the codebase, what resources it has available for it and for how long.
 * Support your experienced policy makers, developers and designers to stay part of the community for as long as possible.
 
 ## Developers and designers: what you need to do

--- a/criteria/require-review.md
+++ b/criteria/require-review.md
@@ -46,11 +46,11 @@ order: 7
 * Make delivering great code a shared objective.
 * Make sure writing and reviewing contributions to source, policy, documentation and tests are considered equally valuable.
 * Create a culture where all contributions are welcome and everyone is empowered to review them.
-* Make sure no contributor is ever alone in contributing to a project.
+* Make sure no contributor is ever alone in contributing to a codebase.
 
 ## Developers and designers: what you need to do
 
-* Ask other contributors on the project to review your work, in your organization or outside of it.
+* Ask other contributors on the codebase to review your work, in your organization or outside of it.
 * Try to respond to others' requests for code review promptly, initially providing feedback about the concept of the change.
 
 ## Further reading

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -37,11 +37,11 @@ order: 3
 ## Policy makers: what you need to do
 
 * Document your policy with enough clarity and detail that it can be understood outside of its original context.
-* Make sure your organization is listed as a known user by the project.
+* Make sure your organization is listed as a known user by the codebase.
 
 ## Management: what you need to do
 
-* Make sure that stakeholders and business owners understand that reusability is an explicit goal of the project as it reduces technical debt and provides sustainability for the codebase.
+* Make sure that stakeholders and business owners understand that reusability is an explicit goal of the codebase as it reduces technical debt and provides sustainability for it.
 
 ## Developers and designers: what you need to do
 

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -9,7 +9,7 @@ order: 10
 * All code and documentation MUST be in English.
 * Any translation MUST be up to date with the English version and vice versa.
 * There SHOULD be no acronyms, abbreviations, puns or legal/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
-* The name of the project or codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or branding.
+* The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or branding.
 * Documentation SHOULD aim for a lower secondary education reading level, as recommended by the [Web Content Accessibility Guidelines 2](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable).
 * Any code, documentation and tests MAY have a translation.
 
@@ -30,7 +30,7 @@ order: 10
 * Validate that no unexplained acronyms, abbreviations, puns or legal/domain specific terms are in the documentation.
 * Test the documentation for grammar using [Grammarly](https://www.grammarly.com/).
 * Test the documentation for readability using [Hemingway text editor](https://hemingwayapp.com/).
-* Ask someone outside of your context if they understand your content (for example, a developer working on a different project).
+* Ask someone outside of your context if they understand your content (for example, a developer working on a different codebase).
 
 
 ## Policy makers: what you need to do


### PR DESCRIPTION
Change all project to codebase to minimize confusion.

Issue #409

-----
[View rendered criteria/continuous-integration.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/continuous-integration.md)
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/document-maturity.md)
[View rendered criteria/open-to-contributions.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/open-to-contributions.md)
[View rendered criteria/require-review.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/require-review.md)
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/reusable-and-portable-codebases.md)
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/ja-codebase-project-take2/criteria/understandable-english-first.md)