### PR TITLE
Make requirement technology independent

### DIFF
--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -7,7 +7,7 @@ order: 5
 ## Requirements
 
 * The codebase MUST have a public issue tracker that accepts suggestions from anyone.
-* The codebase MUST include instructions for how to privately report security issues and do responsible disclosure.
+* The codebase MUST include instructions for how to privately report security issues for responsible disclosure.
 * The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
 * The codebase MUST have communication channels for users and developers, for example email lists.
 * The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -7,7 +7,7 @@ order: 5
 ## Requirements
 
 * The codebase MUST have a public issue tracker that accepts suggestions from anyone.
-* The codebase MUST include an email address for security issues and responsible disclosure.
+* The codebase MUST include instructions for how to privately report security issues and do responsible disclosure.
 * The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
 * The codebase MUST have communication channels for users and developers, for example email lists.
 * The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.


### PR DESCRIPTION
Fixes issue #339.

-----
[View rendered criteria/make-contributing-easy.md](https://github.com/publiccodenet/standard/blob/ja-secure-reporting/criteria/make-contributing-easy.md)