### PR TITLE
Clarify versions may be derived from VCS metadata

### DIFF
--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -41,6 +41,7 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 
 * Add a prominent header to every interface that indicates the maturity level of the code.
 * Version all releases.
+* Especially in 'rolling release' scenario's, the version may be automatically derived from the version control system metadata (e.g. using [git describe](https://git-scm.com/docs/git-describe)).
 
 ## Further reading
 


### PR DESCRIPTION
In continuous deployment/rolling release scenario's, especially
for 'leaf' projects (less so for libraries) it is still important
to have a clear identifier for versions. However, rather than
manually tagging each version, the version would be derived from
the version control system metadata. It might be good to clarify
that explicitly.

References #419

-----
[View rendered criteria/document-maturity.md](https://github.com/raboof/standard/blob/allow-rolling-updates/criteria/document-maturity.md)