### PR TITLE
Fix broken break-word in links

### DIFF
--- a/print.html
+++ b/print.html
@@ -74,6 +74,7 @@
     a[href^="http"]:link {
       color: black;
       text-decoration: none;
+      word-wrap: normal;
     }
     a[href^="http"]:after {
       content: "" attr(href) "";


### PR DESCRIPTION
Breaking word should behave now:

![image](https://user-images.githubusercontent.com/1917629/102378854-87d6ae00-3fc6-11eb-957f-9a8245df1229.png)


Fixes #402