### PR TITLE
Replace unreliable bpmn.org link

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -29,7 +29,7 @@ This makes sure access is guaranteed to both the source code and the policy docu
 ## Policy makers: what you need to do
 
 * Collaborate with developers and designers to ensure there is no mismatch between policy code and source code.
-* Document policy in formats that are unambiguous and machine readable such as [Business Process Model and Notation](http://www.bpmn.org/), [Decision Model and Notation](https://www.omg.org/dmn/) and [Case Management Model Notation](https://www.omg.org/cmmn/).
+* Document policy in formats that are unambiguous and machine readable such as [Business Process Model and Notation](https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation), [Decision Model and Notation](https://www.omg.org/dmn/) and [Case Management Model Notation](https://www.omg.org/cmmn/).
 * Track policy with [the same version control](version-control-and-history.md) and documentation used to track source code.
 * Check in regularly to understand how the non-policy code in the codebase has changed and whether it still matches the [intentions of the policy](document-objectives.md).
 


### PR DESCRIPTION
As http://www.bpmn.org/ has not been reliable, this converts the link to
https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation

-----
[View rendered criteria/bundle-policy-and-code.md](https://github.com/publiccodenet/standard/blob/eh-fix-bpmn-link/criteria/bundle-policy-and-code.md)