### PR TITLE
Use standard 'advertise' in favor of 'advertize'

### DIFF
--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -8,7 +8,7 @@ order: 4
 
 * The codebase MUST allow anyone to submit suggestions for changes to the codebase.
 * The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a `CONTRIBUTING` file.
-* The codebase SHOULD advertize the committed engagement of involved organizations in the development and maintenance.
+* The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
 * The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase SHOULD have a publicly available roadmap.
 * The codebase MAY include a code of conduct for contributors.


### PR DESCRIPTION
This pull request means to resolve #400.

The current situation is that both "advertize" and "advertise" are used. According to the links mentioned in the issue ([Grammarist](https://grammarist.com/spelling/advertise-vs-advertize/) and [StackExchange](https://english.stackexchange.com/questions/341707/should-advertised-be-spelled-with-a-z-in-american-english)), the former is not standard and we should use "advertise" instead.

-----
[View rendered criteria/open-to-contributions.md](https://github.com/Huy-Ngo/standard/blob/develop/criteria/open-to-contributions.md)