### PR TITLE
Move git links to version control and add new in easy contributing

### DIFF
--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -43,7 +43,6 @@ order: 5
 
 ## Further reading
 
-* [GitHub Learning Lab](https://lab.github.com/) for learning git or refresh your skills.
-* [Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf) a list with the most common used git commands.
+* [How to inspire exceptional contributions to your open-source project](https://www.netdata.cloud/blog/open-source-contributions/)
 * [The benefits of coding in the open](https://gds.blog.gov.uk/2017/09/04/the-benefits-of-coding-in-the-open/) by the UK Government Digital Service.
 * [Verdaccio's security policy](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md) is a really nice example.

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -67,3 +67,5 @@ For example, adding a new category of applicant to a codebase that manages grant
 * [Producing OSS: Version Control Vocabulary](https://producingoss.com/en/vc.html#vc-vocabulary) by Karl Fogel.
 * [Maintaining version control in coding](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding) by the UK Government Digital Service.
 * [Semantic Versioning Specification](https://semver.org/) used by many codebases to label versions.
+* [GitHub Learning Lab](https://lab.github.com/) for learning git or refresh your skills.
+* [Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf) a list with the most common used git commands.


### PR DESCRIPTION
The git links fit better in maintain version control while the new link is about getting contributions.

-----
[View rendered criteria/make-contributing-easy.md](https://github.com/publiccodenet/standard/blob/ja-link-shuffle/criteria/make-contributing-easy.md)
[View rendered criteria/version-control-and-history.md](https://github.com/publiccodenet/standard/blob/ja-link-shuffle/criteria/version-control-and-history.md)