### PR TITLE
Remove redundant open standard definitions

### DIFF
--- a/criteria/open-standards.md
+++ b/criteria/open-standards.md
@@ -6,10 +6,10 @@ order: 11
 
 ## Requirements
 
-* For features of a codebase that facilitate the exchange of data the codebase MUST use an open standard that meets the [Open Source Initiative Open Standard Requirements](https://opensource.org/osr).
+* For features of a codebase that facilitate the exchange of data the codebase MUST use an open standard.
 * If no existing open standard is available, effort SHOULD be put into developing one.
 * Standards that are machine testable SHOULD be preferred over those that are not.
-* Functionality using features from a non-open standard (one that doesn't meet the Open Source Initiative Open Standard Requirements) MAY be provided if necessary, but only in addition to compliant features.
+* Functionality using features from a standard that is not an open standard MAY be provided if necessary, but only in addition to compliant features.
 * All non-compliant standards used MUST be recorded clearly in the documentation.
 * The codebase SHOULD contain a list of all the standards used with links to where they are available.
 
@@ -30,7 +30,7 @@ order: 11
 
 ## Policy makers: what you need to do
 
-* Prohibit procurement of technology that does not comply with the Open Source Initiative Open Standard Requirements.
+* Prohibit procurement of technology that does not use open standards.
 
 ## Management: what you need to do
 


### PR DESCRIPTION
It's already well defined in the glossary and we don't need
to repeat that several times.

-----
[View rendered criteria/open-standards.md](https://github.com/publiccodenet/standard/blob/ja-remove-redundant-definition/criteria/open-standards.md)