### PR TITLE
Put attribution after link

### DIFF
--- a/criteria/style.md
+++ b/criteria/style.md
@@ -40,5 +40,5 @@ order: 14
 
 ## Further reading
 
-* [List of linters by Hugo Martins](https://github.com/caramelomartins/awesome-linters).
+* [List of linters](https://github.com/caramelomartins/awesome-linters) by Hugo Martins.
 * [Programming style](https://en.wikipedia.org/wiki/Programming_style) on Wikipedia.


### PR DESCRIPTION
This makes it more consistent with links in other criteria.

-----
[View rendered criteria/style.md](https://github.com/publiccodenet/standard/blob/ja-fix-link-wrap/criteria/style.md)