### PR TITLE
Address Issue#483 link check fails on forks

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
+export PAGES_REPO_NWO=publiccodenet/standard
+
 # Lint markdown using the Markdownlint gem with the default ruleset except for:
 # MD007 Unordered list indentation: we allow sub-lists to also have bullets
 # MD013 Line length: we allow long lines

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
+export PAGES_REPO_NWO=publiccodenet/standard
+
 # Lint markdown using the Markdownlint gem with the default ruleset except for:
 # MD007 Unordered list indentation: we allow sub-lists to also have bullets
 # MD013 Line length: we allow long lines


### PR DESCRIPTION
https://github.com/publiccodenet/standard/issues/483

This commit tells jekyll to build repo links as publiccodenet/standard
links.