### PR TITLE
Extract markdown as separate GH Action step

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,4 +25,5 @@ jobs:
         with:
           ruby-version: '2.7'
       - run: bundle install
+      - run: ./script/test-markdown.sh
       - run: ./script/test-with-link-check.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,6 @@ jobs:
         with:
           ruby-version: '2.7'
       - run: bundle install
-      - run: ./script/cibuild.sh
+      - run: ./script/test-markdown.sh
+      - run: ./script/test-without-link-check.sh
+      - run: ./script/check-new-links.sh

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
-./script/test-without-link-check.sh && ./script/check-new-links.sh
+
+# This is script is referenced by .travis.yml
+
+./script/test-markdown.sh &&
+./script/test-with-link-check.sh &&
+./script/check-new-links.sh

--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Lint markdown using the Markdownlint gem with the default ruleset except for:
+# MD007 Unordered list indentation: we allow sub-lists to also have bullets
+# MD013 Line length: we allow long lines
+# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
+#
+# Additionally, we have these violations which should be resolved:
+# MD026 Trailing punctuation in header
+# MD032 Lists should be surrounded by blank lines
+# MD034 Bare URL used
+#
+bundle exec mdl -r ~MD007,~MD013,~MD029,~MD026,~MD032,~MD034 -i -g '.'

--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -3,18 +3,6 @@ set -e # halt script on error
 
 export PAGES_REPO_NWO=publiccodenet/standard
 
-# Lint markdown using the Markdownlint gem with the default ruleset except for:
-# MD007 Unordered list indentation: we allow sub-lists to also have bullets
-# MD013 Line length: we allow long lines
-# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
-#
-# Additionally, we have these violations which should be resolved:
-# MD026 Trailing punctuation in header
-# MD032 Lists should be surrounded by blank lines
-# MD034 Bare URL used
-#
-bundle exec mdl -r ~MD007,~MD013,~MD029,~MD026,~MD032,~MD034 -i -g '.'
-
 # Build the site
 bundle exec jekyll build
 

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -3,18 +3,6 @@ set -e # halt script on error
 
 export PAGES_REPO_NWO=publiccodenet/standard
 
-# Lint markdown using the Markdownlint gem with the default ruleset except for:
-# MD007 Unordered list indentation: we allow sub-lists to also have bullets
-# MD013 Line length: we allow long lines
-# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
-#
-# Additionally, we have these violations which should be resolved:
-# MD026 Trailing punctuation in header
-# MD032 Lists should be surrounded by blank lines
-# MD034 Bare URL used
-#
-bundle exec mdl -r ~MD007,~MD013,~MD029,~MD026,~MD032,~MD034 -i -g '.'
-
 # Build the site
 bundle exec jekyll build
 


### PR DESCRIPTION
This moves the "bundle exec mdl" into a stand-alone script.
The stand-alone script is now refrenced as a separate "run"
command in both the regular test and cron-nightly actions.
As .travis.yml still references cibuild.sh, it is called
form that script as well.
Developers may still find cibuild.sh handy as a "one stop"
for testing even after we remove .travis.yml from the repo.