### PR TITLE
Rename "Document your objectives" to "Document codebase objectives"

### DIFF
--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -2,7 +2,7 @@
 order: 8
 ---
 
-# Document your objectives
+# Document codebase objectives
 
 ## Requirements
 
@@ -12,7 +12,7 @@ order: 8
 
 ## Why this is important
 
-Documenting your objectives:
+Documenting codebase objectives:
 
 * provides an easy way for people to decide whether this codebase is interesting for them now or in the future.
 * helps scope your own development.

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ The Standard for Public Code gives public organizations a model for building the
   * [Make contributing easy](criteria/make-contributing-easy.md)
   * [Maintain version control](criteria/version-control-and-history.md)
   * [Require review of contributions](criteria/require-review.md)
-  * [Document your objectives](criteria/document-objectives.md)
+  * [Document codebase objectives](criteria/document-objectives.md)
   * [Document the code](criteria/documenting.md)
   * [Use plain English](criteria/understandable-english-first.md)
   * [Use open standards](criteria/open-standards.md)


### PR DESCRIPTION
See issue 489:
https://github.com/publiccodenet/standard/issues/489

And also issue 57:
https://github.com/publiccodenet/standard/issues/57

And PR 310:
https://github.com/publiccodenet/standard/pull/310

Specifically:
https://github.com/publiccodenet/standard/pull/310/files#diff-d312f914fa2b256551adaef30152ec1d1cb908f94dd07174b914011356bbd2d6

-----
[View rendered criteria/document-objectives.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-489/criteria/document-objectives.md)
[View rendered index.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-489/index.md)