### PR TITLE
More "You" and "Your" fixups in requirements

### DIFF
--- a/criteria/code-in-the-open.md
+++ b/criteria/code-in-the-open.md
@@ -9,7 +9,7 @@ order: 1
 * All source code for any policy and software in use (unless used for fraud detection) MUST be published and publicly accessible.
 * Contributors MUST NOT upload sensitive information regarding users, their organization or third parties to the repository.
 * Any source code not currently in use (such as new versions, proposals or older versions) SHOULD be published.
-* The source code MAY provide the general public with insight into which source code or policy underpins any specific interaction they have with your organization.
+* The source code MAY provide the general public with insight into which source code or policy underpins any specific interaction they have with an organization.
 
 ## Why this is important
 

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -13,7 +13,7 @@ order: 9
   * a high level description that is clearly understandable for a wide audience of stakeholders, like the general public and journalists,
   * a section describing how to install and run a standalone version of the source code, including, if necessary, a test dataset,
   * examples for all functionality.
-* There SHOULD be continuous integration tests for the quality of your documentation.
+* There SHOULD be continuous integration tests for the quality of the documentation.
 * The documentation of the codebase MAY contain examples that make users want to immediately start using the codebase.
 * You MAY use the examples in your documentation to test the code.
 

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -15,7 +15,7 @@ order: 9
   * examples for all functionality.
 * There SHOULD be continuous integration tests for the quality of the documentation.
 * The documentation of the codebase MAY contain examples that make users want to immediately start using the codebase.
-* Examples in the documentation MAY be used to test the code.
+* The code MAY be tested by using examples in the documentation.
 
 ## Why this is important
 

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -15,7 +15,7 @@ order: 9
   * examples for all functionality.
 * There SHOULD be continuous integration tests for the quality of the documentation.
 * The documentation of the codebase MAY contain examples that make users want to immediately start using the codebase.
-* You MAY use the examples in your documentation to test the code.
+* Examples in the documentation MAY be used to test the code.
 
 ## Why this is important
 

--- a/criteria/style.md
+++ b/criteria/style.md
@@ -6,10 +6,10 @@ order: 14
 
 ## Requirements
 
-* Contributions MUST adhere to either a coding or writing style guide, either your own or an existing one that is advertised in or part of the codebase.
+* Contributions MUST adhere to either a coding or writing style guide, either the codebase community's own or an existing one that is advertised in or part of the codebase.
 * Contributions SHOULD pass automated tests on style.
-* Your codebase SHOULD include inline comments and documentation for non-trivial sections.
-* You MAY include sections in your style guide on [understandable English](understandable-english-first.md).
+* The codebase SHOULD include inline comments and documentation for non-trivial sections.
+* The style guide MAY include sections on [understandable English](understandable-english-first.md).
 
 ## Why this is important
 

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -6,14 +6,14 @@ order: 6
 
 ## Requirements
 
-* You MUST have a way to maintain version control for the code.
+* The community MUST have a way to maintain version control for the code.
 * All files in a codebase MUST be version controlled.
 * All decisions MUST be documented in commit messages.
 * Every commit message MUST link to discussions and issues wherever possible.
-* You SHOULD use a distributed version control system.
-* You SHOULD group relevant changes in commits.
-* You SHOULD mark different versions of the codebase, for example using revision tags or textual labels.
-* You SHOULD prefer file formats where the changes within the files can be easily viewed and understood in the version control system.
+* The codebase SHOULD be maintained in a distributed version control system.
+* Contributors SHOULD group relevant changes in commits.
+* Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels.
+* Contributors SHOULD prefer file formats where the changes within the files can be easily viewed and understood in the version control system.
 
 ## Why this is important
 


### PR DESCRIPTION
This  contains a number of small "your codebase" to "the codebase"
sorts of changes as discussed in Issue 57.

[Issue#57](https://github.com/publiccodenet/standard/issues/57)

We certainly want to keep the "you" langauge in the "what you must do" sections
however, I'm not sure about the "why this is important" or "what this does not do"
sections, thus those are not a part of this merge request.

-----
[View rendered criteria/code-in-the-open.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-57-style-202105/criteria/code-in-the-open.md)
[View rendered criteria/documenting.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-57-style-202105/criteria/documenting.md)
[View rendered criteria/style.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-57-style-202105/criteria/style.md)
[View rendered criteria/version-control-and-history.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue-57-style-202105/criteria/version-control-and-history.md)