### PR TITLE
Clarify what kinds of contributions are welcome

### DIFF
--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -7,7 +7,7 @@ order: 4
 ## Requirements
 
 * The codebase MUST allow anyone to submit suggestions for changes to the codebase.
-* The codebase MUST include contribution guidelines explaining how contributors can get involved, for example in a `CONTRIBUTING` file.
+* The codebase MUST include contribution guidelines explaining what kinds of contributions are welcome and how contributors can get involved, for example in a `CONTRIBUTING` file.
 * The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
 * The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase SHOULD have a publicly available roadmap.


### PR DESCRIPTION
Contribution guidelines have a tendency to focus on code contributions, while
other contributions (for example around UX) can be at least as valuable. I
don't think the Standard for Public Code should dictate what kinds of
contributions a project must accept, but having projects think about this and
write that down in their contribution guidelines should be a good starting
point.

This repo itself already does this to some extent: it calls out we
welcome contributions not just by technologists but also policy makers
and 'interested folk', and that we appreciate both feedback and
improvements.

This was sparked by a [thread on
slack](https://app.slack.com/client/T68FXPFQV/C68APRNNP/thread/C68APRNNP-1622901681.083200)

-----
[View rendered criteria/open-to-contributions.md](https://github.com/raboof/standard/blob/encourage-clarifying-what-kinds-of-contributions-are-welcome/criteria/open-to-contributions.md)