### PR TITLE
Issue#509 publiccode.yml SHOULD or MAY

### DIFF
--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -11,7 +11,7 @@ order: 3
 * The codebase SHOULD be in use by multiple parties.
 * The roadmap SHOULD be influenced by the needs of multiple parties.
 * Configuration SHOULD be used to make code adapt to context specific needs.
-* Codebases SHOULD include a [publiccode.yml](https://github.com/italia/publiccode.yml) metadata description so that they're easily discoverable.
+* The codebase SHOULD include a machine readable metadata description, for example in a [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) file.
 * Code and its documentation SHOULD NOT contain situation-specific information.
 
 ## Why this is important
@@ -20,6 +20,7 @@ order: 3
 * Makes the code easier for new people to understand (as it's more general).
 * Makes it easier to control the mission, vision and scope of the codebase because the codebase is thoughtfully and purposefully designed for reusability.
 * Codebases used by multiple parties have broad enough value to be Public Code and are more likely to benefit from a self-sustaining community.
+* A metadata description file increases discoverability.
 * Any contributor is able to test and contribute without relying on the situation-specific infrastructure of any other contributor or deployment.
 
 ## What this does not do


### PR DESCRIPTION
Based on the discussion on Issue #509, this patch puts the intent forward
without making the technology choice the focus of the requirement.

This patch also updates the link to the new github repo location for
publiccodeyml.

https://github.com/publiccodenet/standard/issues/509

-----
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/eh-issue-509-20210816/criteria/reusable-and-portable-codebases.md)