### PR TITLE
Replace "our organization" with Foundation for Public Code

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -96,13 +96,13 @@ To use existing public code, you need to specify in your budget and project desi
 
 The Foundation for Public Code ensures that codebases under its stewardship (and not in incubation or the attic) are compliant with the Standard for Public Code. This makes clear to potential users and contributors that the codebase is of high quality, and updates will be too.
 
-The audit performed by our organization is meant to complement machine testing, as machines are great at testing things like syntax and whether outcomes align with expectations. Things meant for humans, such as testing whether documentation is actually understandable and accessible in context, the commit messages make sense, and whether community guidelines are being followed are impossible for machines to test.
+The audit performed by the Foundation for Public Code is meant to complement machine testing, as machines are great at testing things like syntax and whether outcomes align with expectations. Things meant for humans, such as testing whether documentation is actually understandable and accessible in context, the commit messages make sense, and whether community guidelines are being followed are impossible for machines to test.
 
-The audit tests the entire codebase, including source code, policy, documentation and conversation for compliance with both the standards set out by our organization and the standards set out in the codebase itself.
+The audit tests the entire codebase, including source code, policy, documentation and conversation for compliance with both the standards set out by the Foundation for Public Code and the standards set out in the codebase itself.
 
 ### How the process works
 
-Every time a contribution is suggested to a codebase – through for instance a merge request – the [codebase stewards](https://about.publiccode.net/roles/) of our organization will audit the contribution for compliance with the Standard for Public Code. New contributions can only be adopted into the codebase after they have been approved as compliant with the Standard for Public Code, and have been reviewed by another contributor.
+Every time a contribution is suggested to a codebase – through for instance a merge request – the [codebase stewards](https://about.publiccode.net/roles/) of the Foundation for Public Code will audit the contribution for compliance with the Standard for Public Code. New contributions can only be adopted into the codebase after they have been approved as compliant with the Standard for Public Code, and have been reviewed by another contributor.
 
 The audit is presented as a review of the contribution. The codebase steward gives line by line feedback and compliance, helping the contributor to improve their contribution. The merge request cannot be fulfilled until the codebase stewards have approved the contribution.
 

--- a/print.html
+++ b/print.html
@@ -407,7 +407,7 @@
 
     <h1>Contact</h1>
 
-    <p>For questions and more information about our organization you can find us at <a href="https://publiccode.net">our website</a>, email us at info@publiccode.net, or call us at +31 20 2 444 500</p>
+    <p>For questions and more information about the Foundation for Public Code you can find us at <a href="https://publiccode.net">our website</a>, email us at info@publiccode.net, or call us at +31 20 2 444 500</p>
 
   </article>
 


### PR DESCRIPTION
See https://github.com/publiccodenet/standard/issues/453

```
sed -i -e's/\bour organization/the Foundation for Public Code/g' \
  $(git grep -il '\bour organization')
```

-----
[View rendered introduction.md](https://github.com/ericherman/standard-for-public-code/blob/eh-issue453-20210817/introduction.md)