### PR TITLE
First iteration of the Unofficial Spanish Translation of the Standard

### DIFF
--- a/unofficial-spanish-translation/README.md
+++ b/unofficial-spanish-translation/README.md
@@ -1,0 +1,43 @@
+# Estándar para el Código Público
+
+IMPORTANTE: Este repositorio cuenta con una traducción al español del Standard for Public Code o Estándar para el Código Abierto. Esta traducción refleja la versión 0.2.1 del Estándar para el Código Abierto. Puede encontrar la última versión actualizada del Estándar en inglés en [el repositorio oficial de dicho documento](https://github.com/publiccodenet/standard).
+
+![version 0.2.1](https://img.shields.io/badge/version-0.2.1-red.svg)
+
+## Contribuye
+
+Creemos que las políticas públicas y el software deben ser inclusivos, utilizables, abiertos, legibles, responsables, accesibles y sostenibles. Esto significa que necesitamos una nueva forma de diseñar, desarrollar y adquirir tanto el código fuente como la documentación de las políticas.
+
+Este estándar establece un nivel de calidad para las codebases que satisface las necesidades de las organizaciones, instituciones y administraciones públicas, así como de otros servicios infraestructurales críticos.
+
+El estándar vive en [standard.publiccode.net](https://standard.publiccode.net/). Echa un vistazo a [`index.md`](index.md) para una idea general del contenido.
+
+[![Thumbnail for the video on the Standard for Public Code: a printed version lying on a table between two hands](https://img.youtube.com/vi/QWt6vB-cipE/mqdefault.jpg)](https://www.youtube.com/watch?v=QWt6vB-cipE)
+
+[Una introducción al Estándar para el Código Abierto - Creative Commons Global Summit 2020 (4:12) en YouTube](https://www.youtube.com/watch?v=QWt6vB-cipE)
+
+## Ayuda a mejorar el estándar
+
+Estamos buscando a personas como tú para [contribuir](CONTRIBUTING.md) a este proyecto a través de la sugerencia de mejoras y soporte en cuanto al desarrollo del mismo. 😊 Puedes comenzar leyendo nuestra [contributors guide](CONTRIBUTING.md). Dado que se trata de un documento clave, aceptaremos contribuciones cuando añadan un valor significativo. Hemos descrito cómo gestionamos la comunidad entorno al estándar en el [governance statement](GOVERNANCE.md).
+
+Por favor ten en cuenta que este proyecto ha sido publicado con un [contributor code of conduct](CODE_OF_CONDUCT.md). Cuando participas en el proyecto aceptas cumplir dichos términos. Por favor, sé amable con el resto de personas implicadas en el proyecto.
+
+## Previsualizar, construir y desplegar
+
+El repositorio se construye en un sitio estático desplegado en [standard.publiccode.net](https://standard.publiccode.net/). Está construido con [GitHub pages](https://pages.github.com) y [Jekyll](https://jekyllrb.com/).
+
+Ve los scripts en la carpeta `script`.
+
+## Generar un PDF del Estándar de Código Abierto
+
+Usando [Weasyprint](https://weasyprint.org/) la carpeta `print.html` puede ser convertida en un PDF decente.
+
+```bash
+weasyprint http://localhost:4000/print.html standard.pdf
+```
+
+## Licencia
+
+© [Los autores y contribuyentes](AUTHORS.md)
+
+El estándar cuenta con una [licencia](LICENSE.md) CC 0, la cual también se extiende a todas las ilustraciones y la documentación. Esto significa que cualquier persona puede hacer lo que considere con el documento. Si tú contribuyes, también adquieres dichos derechos applies to all illustrations and the documentation. This means anyone can do anything with it. Si contribuyes, también concedes estos derechos a otros. Puedes encontrar más información sobre cómo ayudar en la [contributing guide](CONTRIBUTING.md).

--- a/unofficial-spanish-translation/criterios/_plantilla.md
+++ b/unofficial-spanish-translation/criterios/_plantilla.md
@@ -1,0 +1,17 @@
+# Nombre
+
+## Requerimientos
+
+## Por qué es importante
+
+## Qué no hace
+
+## Cómo testear
+
+## Responsables políticos y legisladores: qué necesitan hacer
+
+## Managers: qué necesitan hacer
+
+## Desarrolladores de software y diseñadores: qué necesitan hacer
+
+## Más información

--- a/unofficial-spanish-translation/criterios/codigo-en-abierto.md
+++ b/unofficial-spanish-translation/criterios/codigo-en-abierto.md
@@ -1,0 +1,58 @@
+---
+order: 1
+---
+
+# Código en abierto
+
+## Requerimientos
+
+* Todo el código fuente de cualquier política y software en uso (a menos que se utilice para la detección de fraudes) DEBE publicarse y ser de acceso público.
+* Los colaboradores NO DEBEN subir al repositorio información sensible sobre los usuarios, su organización o terceros.
+* Cualquier código fuente que no esté actualmente en uso (como nuevas versiones, propuestas o versiones antiguas) DEBE ser publicado.
+* El código fuente PUEDE proporcionar al público en general información sobre el código fuente o la política que sustenta cualquier interacción específica que tengan con una organización.
+
+## Por qué esto es importante
+
+Mantener el código en abierto:
+
+* mejora la transparencia
+* aumenta la calidad del código
+* facilita las auditorías
+
+## Qué no hace
+
+* Hace el código fuente o política reusable.
+* Hace entendibles al mayor número de personas posible la codebase y el código que contiene.
+
+## Cómo testear
+
+El origen de cada versión en uso es publicado en internet donde puede ser visto:
+
+* desde fuera de la organización que ha contribuido
+* sin la necesidad de forma alguna de autentificación o autorización
+
+Por cada commit, los revisores o reviewers verifican que el contenido no incluye informaicón sensible como pueden ser configuraciones, nombres de usuarios o contraseñas, claves públicas o cualquier otra credencial utilizada en sistemas en producción.
+
+## Responsables políticos o legistadores: qué necesitan hacer
+
+* Desarrollar políticas en abierto.
+* Priorizar políticas en abierto y transparentes.
+
+## Mánagers: qué necesitan hacer
+
+* Desarrollar una cultura que abrace la apertura, el aprendizaje y la retroalimentación.
+* Colaborar con empresas externas y profesionales autónomos a través del trabajo en abierto.
+
+## Desarrolladores de software y diseñadores: qué necesitan hacer
+
+* Dividir de forma clara los datos y el código, de tal manera que se pueda alcanzar el requerimiento sobre información sensible mencionado con anterioridad.
+
+## Más información (en inglés)
+
+* [Mantener el código en abierto](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/) por el Servicio del Gobierno Digital del Reino Unido.
+* [Cuándo el código debería de estar en abierto y cuándo cerrado](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed) by the UK Government Digital Service.
+* [Consideraciones de seguridad cuando se considere el código en abierto](https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open) por el Servicio del Gobierno Digital del Reino Unido.
+* [Desplegando el software con regularidad](https://www.gov.uk/service-manual/technology/deploying-software-regularly) por el Servicio del Gobierno Digital del Reino Unido.
+* [Cómo GDS usa GitHub](https://gdstechnology.blog.gov.uk/2014/01/27/how-we-use-github/) por el Servicio del Gobierno Digital del Reino Unido.
+
+


### PR DESCRIPTION
- Folder created
- Readme translated into Spanish and included into the previous folder
- Template translated for criteria creation
- First criteria translated into Spanish

-----
[View rendered unofficial-spanish-translation/README.md](https://github.com/publiccodenet/standard/blob/unofficial-spanish-translation/unofficial-spanish-translation/README.md)
[View rendered unofficial-spanish-translation/criterios/_plantilla.md](https://github.com/publiccodenet/standard/blob/unofficial-spanish-translation/unofficial-spanish-translation/criterios/_plantilla.md)
[View rendered unofficial-spanish-translation/criterios/codigo-en-abierto.md](https://github.com/publiccodenet/standard/blob/unofficial-spanish-translation/unofficial-spanish-translation/criterios/codigo-en-abierto.md)