### PR TITLE
MUST be in English, SHOULD be plain English

### DIFF
--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -6,7 +6,7 @@ order: 10
 
 ## Requirements
 
-* All codebase documentation MUST be in plain English.
+* All codebase documentation MUST be in English.
 * All code MUST be in English, except where required to execute as policy.
 * Any translation MUST be up to date with the English version and vice versa.
 * There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.

--- a/glossary.md
+++ b/glossary.md
@@ -32,10 +32,6 @@ Open source is defined by the Open Source Initiative in their [Open Source Defin
 
 An open standard is any standard that meets the Open Source Initiative's [Open Standard Requirements](https://opensource.org/osr).
 
-## Plain English
-
-English on a lower secondary education reading level, as recommended by the [Web Content Accessibility Guidelines 2](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable).
-
 ## Policy
 
 A policy is a deliberate system of principles to guide decisions and achieve rational outcomes.


### PR DESCRIPTION
Upon re-reading it became evident that the SHOULD requirements
together comprise the concept of "plain English" for codebases
and the glossary definition needed to be exapanded or removed.

It did not make sense to put a MUST on "plain English" and a
SHOULD for all of the elements of "plain English". We believe
the spirit should clearly be a MUST for English and SHOULD be
as plain as possible.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

-----
[View rendered criteria/understandable-english-first.md](https://github.com/ericherman/standard-for-public-code/blob/revert-plain-english/criteria/understandable-english-first.md)
[View rendered glossary.md](https://github.com/ericherman/standard-for-public-code/blob/revert-plain-english/glossary.md)