### PR TITLE
Clarify exception to English wording

### DIFF
--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -7,7 +7,7 @@ order: 10
 ## Requirements
 
 * All codebase documentation MUST be in English.
-* All code MUST be in English, except where required to execute as policy.
+* All code MUST be in English, except where policy is machine interpreted as code.
 * Any translation MUST be up to date with the English version and vice versa.
 * There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
 * The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.


### PR DESCRIPTION
We want to be clear that in cases where policy is being executed directly
as code that the policy would not be expected to be in English.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

-----
[View rendered criteria/understandable-english-first.md](https://github.com/ericherman/standard-for-public-code/blob/english-except-policy/criteria/understandable-english-first.md)