### PR TITLE
Issue #557, Align cover with inner text

### DIFF
--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -6,7 +6,7 @@ order: 8
 
 ## Requirements
 
-* The codebase MUST contain documentation of its objectives – like a mission and goal statement – that is understandable by designers and developers so that they can use or contribute to the codebase.
+* The codebase MUST contain documentation of its objectives – like a mission and goal statement – that is understandable by developers and designers so that they can use or contribute to the codebase.
 * Codebase documentation SHOULD clearly describe the connections between policy objectives and codebase objectives.
 * The codebase MAY contain documentation of its objectives for the general public.
 

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -35,7 +35,7 @@ order: 10
 
 ## Policy makers: what you need to do
 
-* Frequently test with other management, designers and developers in the process if they understand what you are delivering and how you document it.
+* Frequently test with other management, developers and designers in the process if they understand what you are delivering and how you document it.
 
 ## Management: what you need to do
 

--- a/print-cover.html
+++ b/print-cover.html
@@ -235,7 +235,7 @@
         <lh>What public code is and how to implement it for:</lh>
         <li id="first-page-policy-makers-what-you-need-to-do">Policy makers</li>
         <li id="first-page-management-what-you-need-to-do">Management</li>
-        <li id="first-page-developers-and-designers-what-you-need-to-do">Designers and developers</li>
+        <li id="first-page-developers-and-designers-what-you-need-to-do">Developers and designers</li>
       </ul>
 
       <img src="assets/hands-shake.svg" alt="hands shaking">

--- a/print.html
+++ b/print.html
@@ -273,7 +273,7 @@
       <lh>What public code is and how to implement it for:</lh>
       <li id="first-page-policy-makers-what-you-need-to-do">Policy makers</li>
       <li id="first-page-management-what-you-need-to-do">Management</li>
-      <li id="first-page-developers-and-designers-what-you-need-to-do">Designers and developers</li>
+      <li id="first-page-developers-and-designers-what-you-need-to-do">Developers and designers</li>
     </ul>
 
     <img src="assets/hands-shake.svg" alt="hands shaking">


### PR DESCRIPTION
Prior to this commit, the cover contained the text:

> What public code is and how to implement it for:
> P Policy makers
> M Management
> D Designers and developers

Yet, in each criterion we have a section titled:

> D Developers and designers: what you need to do

This commit makes the cover match the section headings.

Additionally, prior to this commit, when referring to
contributors, in all but two places the text had
"developers and designers"; there were two places which
listed them in the other order, which might suggest to a
reader that special emphasis for designers was needed.

-----
[View rendered criteria/document-objectives.md](https://github.com/ericherman/standard-for-public-code/blob/issue-557-eh/criteria/document-objectives.md)
[View rendered criteria/understandable-english-first.md](https://github.com/ericherman/standard-for-public-code/blob/issue-557-eh/criteria/understandable-english-first.md)