### PR TITLE
Change "and" to "or" for translations

### DIFF
--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -12,7 +12,7 @@ order: 10
 * There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
 * The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.
 * Documentation SHOULD aim for a lower secondary education reading level, as recommended by the [Web Content Accessibility Guidelines 2](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable).
-* Any code, documentation and tests MAY have a translation.
+* Any code, documentation or tests MAY have a translation.
 
 ## Why this is important
 


### PR DESCRIPTION
The "and" could be interpreted to mean that if you have translations for documentation but not the code, you are not standard compliant. And I would think that you would almost never translate the code by changing the name of functions and variables to non-English, even if you have a multilingual interface and translations of the docs. Changing it to "or" would make clear that this is not the intention of this requirement.

-----
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/translation-clarification/criteria/understandable-english-first.md)