### PR TITLE
Only require English summary for bundled non-English policies issue#223

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -29,7 +29,7 @@ This makes sure access is guaranteed to both the source code and the policy docu
 ## Policy makers: what you need to do
 
 * Collaborate with developers and designers to ensure there is no mismatch between policy code and source code.
-* Provide the relevant policy texts for inclusion in the repository.
+* Provide the relevant policy texts for inclusion in the repository; if the text is not available in English, also provide an English summary.
 * Provide references and links to texts which support the policies.
 * Document policy in formats that are unambiguous and machine readable such as [Business Process Model and Notation](https://en.wikipedia.org/wiki/Business_Process_Model_and_Notation), [Decision Model and Notation](https://www.omg.org/dmn/) and [Case Management Model Notation](https://www.omg.org/cmmn/).
 * Track policy with [the same version control](version-control-and-history.md) and documentation used to track source code.

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -8,6 +8,7 @@ order: 10
 
 * All codebase documentation MUST be in English.
 * All code MUST be in English, except where policy is machine interpreted as code.
+* All bundled policy not available in English MUST have an accompanying summary in English.
 * Any translation MUST be up to date with the English version and vice versa.
 * There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
 * The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.


### PR DESCRIPTION
Here is a draft for how to add nuance for non-Enlish legal text in Use Plain English.

-----
[View rendered criteria/bundle-policy-and-code.md](https://github.com/ericherman/standard-for-public-code/blob/non-english-policy-223/criteria/bundle-policy-and-code.md)
[View rendered criteria/understandable-english-first.md](https://github.com/ericherman/standard-for-public-code/blob/non-english-policy-223/criteria/understandable-english-first.md)