### PR TITLE
Capitalize the word not in requirement.

### DIFF
--- a/criteria/require-review.md
+++ b/criteria/require-review.md
@@ -12,7 +12,7 @@ order: 7
 * Contributions SHOULD conform to the standards, architecture and decisions set out in the codebase in order to pass review.
 * Reviews SHOULD include running both the code and the tests of the codebase.
 * Contributions SHOULD be reviewed by someone in a different context than the contributor.
-* Version control systems SHOULD not accept non-reviewed contributions in release versions.
+* Version control systems SHOULD NOT accept non-reviewed contributions in release versions.
 * Reviews SHOULD happen within two business days.
 * Reviews MAY be performed by multiple reviewers.
 


### PR DESCRIPTION
Fixes #561.

-----
[View rendered criteria/require-review.md](https://github.com/publiccodenet/standard/blob/capitalize-not/criteria/require-review.md)