### PR TITLE
Review of the word reuse

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -14,7 +14,7 @@ order: 2
 
 ## Why this is important
 
-This makes sure access is guaranteed to both the source code and the policy documents to facilitate effective reuse of a codebase.
+This makes sure access is guaranteed to both the source code and the policy documents to facilitate effective understanding and reuse of, as well as collaboration in, a codebase.
 
 ## What this does not do
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -33,7 +33,7 @@ order: 4
 ## Policy makers: what you need to do
 
 * Add a list to the codebase of any other resources that policy experts, non-governmental organizations and academics would find useful for understanding or reusing your policy.
-* Consider adding contact details so that other policy makers considering reuse can ask you for advice.
+* Consider adding contact details so that other policy makers considering collaboration can ask you for advice.
 
 ## Management: what you need to do
 

--- a/glossary.md
+++ b/glossary.md
@@ -57,7 +57,7 @@ By developing public code independently from but still implementable in the loca
 * take as a starting point to continue development
 * use as a basis for learning
 
-To facilitate re-use, public code should be either released into the public domain or licensed with an open license that permits others to view and reuse the work freely and to produce derivative works.
+To facilitate reuse, public code should be either released into the public domain or licensed with an open license that permits others to view and reuse the work freely and to produce derivative works.
 
 ## Repository
 

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the Standard for Public Code.
 
-We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for reuse.
+We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for collaboration.
 
 The Standard for Public Code gives public organizations a model for building their own open source solutions to enable successful future reuse by similar public organizations in other places. It includes guidance for policy makers, city administrators, developers and vendors.
 

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the Standard for Public Code.
 
-We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for collaboration.
+We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for collaboration and reuse.
 
 The Standard for Public Code gives public organizations a model for building their own open source solutions to enable successful future reuse by similar public organizations in other places. It includes guidance for policy makers, city administrators, developers and vendors.
 


### PR DESCRIPTION
A review of the word reuse has been made and changed to collaboration where it seems to be the intention (most places where it was used were kept).
Harmonization of spelling to reuse.

Fixes #543

-----
[View rendered criteria/bundle-policy-and-code.md](https://github.com/publiccodenet/standard/blob/review-reuse/criteria/bundle-policy-and-code.md)
[View rendered criteria/open-to-contributions.md](https://github.com/publiccodenet/standard/blob/review-reuse/criteria/open-to-contributions.md)
[View rendered glossary.md](https://github.com/publiccodenet/standard/blob/review-reuse/glossary.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/review-reuse/index.md)