### PR TITLE
Add missing period in Further reading

### DIFF
--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -43,6 +43,6 @@ order: 5
 
 ## Further reading
 
-* [How to inspire exceptional contributions to your open-source project](https://www.netdata.cloud/blog/open-source-contributions/)
+* [How to inspire exceptional contributions to your open-source project](https://www.netdata.cloud/blog/open-source-contributions/).
 * [The benefits of coding in the open](https://gds.blog.gov.uk/2017/09/04/the-benefits-of-coding-in-the-open/) by the UK Government Digital Service.
 * [Verdaccio's security policy](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md) is a really nice example.


### PR DESCRIPTION
Fixes #459.

All other further reading bullet points had periods, so added one to the only one missing. 

-----
[View rendered criteria/make-contributing-easy.md](https://github.com/publiccodenet/standard/blob/consistent-periods/criteria/make-contributing-easy.md)