### PR TITLE
Changed 'your' to 'the' for solution, codebase and content

### DIFF
--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -15,7 +15,7 @@ order: 4
 
 ## Why this is important
 
-* Helps newcomers understand and trust your codebase community's leadership.
+* Helps newcomers understand and trust the codebase community's leadership.
 * Prevents the community that works on a codebase splitting because there is no way to influence its goals and progress – resulting in diverging communities.
 * Helps users decide to use one codebase over another.
 

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -50,7 +50,7 @@ Source should be designed:
 
 * for reuse by other users and organizations,
 * to solve a general problem instead of a specific one,
-* so that someone in a similar organization facing a similar problem would be able to use (parts of) your solution.
+* so that someone in a similar organization facing a similar problem would be able to use (parts of) the solution.
 
 If your context requires deploying to proprietary platforms or using proprietary components, ensure that collaborators can develop, use, test, and deploy without them.
 

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -32,7 +32,7 @@ order: 10
 * Validate that no unexplained acronyms, abbreviations, puns or legal/domain specific terms are in the documentation.
 * Test the documentation for grammar using [Grammarly](https://www.grammarly.com/).
 * Test the documentation for readability using [Hemingway text editor](https://hemingwayapp.com/).
-* Ask someone outside of your context if they understand your content (for example, a developer working on a different codebase).
+* Ask someone outside of your context if they understand the content (for example, a developer working on a different codebase).
 
 ## Policy makers: what you need to do
 


### PR DESCRIPTION
Fixes #589

-----
[View rendered criteria/open-to-contributions.md](https://github.com/publiccodenet/standard/blob/change-your-to-the/criteria/open-to-contributions.md)
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/publiccodenet/standard/blob/change-your-to-the/criteria/reusable-and-portable-codebases.md)
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/change-your-to-the/criteria/understandable-english-first.md)