### PR TITLE
Force size of badge image

### DIFF
--- a/print.html
+++ b/print.html
@@ -279,9 +279,8 @@
     <img src="assets/hands-shake.svg" alt="hands shaking">
 
     <p>Version {{ site.version }}</p>
-    <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0"></p>
+    <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
     <p>github.com/publiccodenet/standard</p>
-    <p><img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
   </article>
 
   <article id="section-authors">

--- a/print.html
+++ b/print.html
@@ -279,7 +279,7 @@
     <img src="assets/hands-shake.svg" alt="hands shaking">
 
     <p>Version {{ site.version }}</p>
-    <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
+    <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0" height="46"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
     <p>github.com/publiccodenet/standard</p>
   </article>
 

--- a/script/pdf.sh
+++ b/script/pdf.sh
@@ -1,2 +1,2 @@
-weasyprint http://localhost:4000/print.html standard.pdf
+weasyprint http://localhost:4000/print.html standard.pdf --presentational-hints
 weasyprint http://localhost:4000/print-cover.html standard-cover.pdf


### PR DESCRIPTION
Forced through the [--presentational-hints](https://doc.courtbouillon.org/weasyprint/latest/api_reference.html#supported-features?highlight=presentational) flag.

Moved the badge next to license image to fit on the front page.

Fixes #593