### PR TITLE
Add dpg badge to the print cover

### DIFF
--- a/print-cover.html
+++ b/print-cover.html
@@ -242,6 +242,7 @@
 
       <div id="version-info">
         <p>Version {{ site.version }}</p>
+        <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0" height="46"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
         <p>https://standard.publiccode.net/</p>
       </div>
     </section>

--- a/script/pdf.sh
+++ b/script/pdf.sh
@@ -1,2 +1,2 @@
 weasyprint http://localhost:4000/print.html standard.pdf --presentational-hints
-weasyprint http://localhost:4000/print-cover.html standard-cover.pdf
+weasyprint http://localhost:4000/print-cover.html standard-cover.pdf --presentational-hints


### PR DESCRIPTION
The file standard-cover.pdf generated by the pdf script did not used the DPG badge, only the version with the full text did. This harmonizes the pdf's to look the same on the front page.