### PR TITLE
Add guide about language style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ Add your changes in commits [with a message that explains them](https://robots.t
 
 If you are adding code, make sure you've added and updated the relevant documentation and tests before you submit your pull request. Make sure to write tests that show the behavior of the newly added or changed code.
 
+#### Style
+
+The Standard for Public Code aims to [use plain English](https://standard.publiccode.net/criteria/understandable-english-first.html) and we have chosen American English for spelling.
+However, we want to emphasize that it is more important that you make your contribution than worry about spelling and typography.
+We will help you get it right in our review process and we also have a separate quality check before [making a new release](docs/releasing.md).
+
 ### 2. Pull request
 
 When submitting the pull request, please accompany it with a description of the problem you are trying to solve and the issue numbers that this pull request fixes.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,6 +3,7 @@
 1. Review state of the 'develop' branch
     - Ensure all changes intended for release are merged
     - Invite a proofread of the current state of the branch
+        - If new dashes are introduced, check if the language can be simplified to remove them in favor of more simple sentences. If a complex sentece is needed, see if the dash can be replaced with other punction. If a dash is truly the best expression of ideas, then follow the [Chicago Manual of Style](https://en.wikipedia.org/wiki/Dash#En_dash_versus_em_dash).
 2. Create a release branch
     - From 'develop', `git checkout -b "release-$MAJOR.$MINOR.$PATCH"`
 3. Update the new release


### PR DESCRIPTION
I am not sure if we want to document more closely the exact rules for dashes in the release guide or if this is enough.

Addresses the process part of #586

-----
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/standard/blob/contributing-style-guide/CONTRIBUTING.md)
[View rendered docs/releasing.md](https://github.com/publiccodenet/standard/blob/contributing-style-guide/docs/releasing.md)