### PR TITLE
Add links to community translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ March 15th 2022: 📜 the ninth draft allows English summaries for policy lackin
 * Emphasize reusability also on parts of the solutions in Create reusable and portable code.
 * Expand guidance to Developers and designers in Create reusable and portable code about deploying to proprietary platforms.
 * Add nuance to use of non-English terms in what management need to do in Use plain English.
-* Change the pull request process diagram to use Mermaid instead of BPMN to make community translations easier.
+* Change the pull request process diagram to use Mermaid instead of BPMN to make [community translations](https://github.com/publiccodenet/community-translations-standard) easier.
 * Added Maurice Hendriks to AUTHORS.
 * Added OpenApi Specification to further reading.
 * Made the attributions in further reading sections clearer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,10 @@ Your ideas, documentation and code have become an integral part of this project.
 
 In fact, feel free to open a pull request to add your name to the [`AUTHORS`](AUTHORS.md) file and get eternal attribution.
 
+## Translations
+
+While the Standard does not have any official translations, you can help maintain existing and add new [community translations of the Standard](https://github.com/publiccodenet/community-translations-standard).
+
 ---
 
 For more information on how to use and contribute to this project, please read the [`README`](README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Your ideas, documentation and code have become an integral part of this project.
 
 In fact, feel free to open a pull request to add your name to the [`AUTHORS`](AUTHORS.md) file and get eternal attribution.
 
-## Translations
+## Translations in other languages
 
 While the Standard does not have any official translations, you can help maintain existing and add new [community translations of the Standard](https://github.com/publiccodenet/community-translations-standard).
 

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ We define ‘public code’ as open source software developed by public organiza
 
 The Standard for Public Code gives public organizations a model for building their own open source solutions to enable successful future reuse by similar public organizations in other places. It includes guidance for policy makers, city administrators, developers and vendors.
 
+There are also unofficial [community translations of the Standard](https://publiccodenet.github.io/community-translations-standard/) in other languages.
+
 * [Introduction and background](introduction.md)
 * [Readers guide: how to interpret this standard](readers-guide.md)
 * [Glossary](glossary.md)


### PR DESCRIPTION
Intentionally skipped the footer for now, since that requires a change in the theme as well.

Aims to fix #610.

-----
[View rendered CHANGELOG.md](https://github.com/publiccodenet/standard/blob/linking-community-standards/CHANGELOG.md)
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/standard/blob/linking-community-standards/CONTRIBUTING.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/linking-community-standards/index.md)