### PR TITLE
s/SHOULD/MUST/ document the governance

### DIFF
--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -8,8 +8,8 @@ order: 4
 
 * The codebase MUST allow anyone to submit suggestions for changes to the codebase.
 * The codebase MUST include contribution guidelines explaining what kinds of contributions are welcome and how contributors can get involved, for example in a `CONTRIBUTING` file.
+* The codebase MUST document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
-* The codebase SHOULD document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 * The codebase SHOULD have a publicly available roadmap.
 * The codebase MAY include a code of conduct for contributors.
 
@@ -37,6 +37,8 @@ order: 4
 
 ## Management: what you need to do
 
+* Make sure that the documentation of the governance includes the current process for how to make changes to the governance.
+* If the community has some consensus about how the governance should change, then include those ideas stated as ambitions in the documentation.
 * Make sure the documentation explains how each organization is involved in the codebase, what resources it has available for it and for how long.
 * Support your experienced policy makers, developers and designers to stay part of the community for as long as possible.
 


### PR DESCRIPTION
Fixes #282
Increase requiment about governance documentation from SHOULD to MUST,
include Management guidance for inclusion of change process and
ambitions of governance evolution.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

-----
[View rendered criteria/open-to-contributions.md](https://github.com/ericherman/standard-for-public-code/blob/must-doc-governanc-282/criteria/open-to-contributions.md)