### PR TITLE
Update release steps to match process

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,21 +20,30 @@
         - If needed for release, reviewers may create PRs to resolve issues
         - Re-request reviews if additional PRs are merged into release branch
     - [ ] Once reviews are complete, merge to 'main'
+4. Create GitHub release with the release notes and version number
     - [ ] Switch to the 'main' branch, `git pull` and `git status`
+    - [ ] `git tag $MAJOR.$MINOR.$PATCH`
+    - [ ] `git push --tags`
+    - [ ] From https://github.com/publiccodenet/standard/tags select "create release"
+        - Title the release
+        - Add changelog bullets
+5. Trigger a rebuild of gh-pages
+    - [ ] `git checkout -b rebuild-gh-pages-$MAJOR.$MINOR.$PATCH`
+    - [ ] `git commit --allow-empty -m"Rebuild GH Pages $MAJOR.$MINOR.$PATCH"`
+    - [ ] `git push -u origin rebuild-gh-pages-$MAJOR.$MINOR.$PATCH`
+    - [ ] Open a pull request from this branch to `main`
+    - [ ] Approve and merge PR (containing empty commit)
+5. PDF Generation
     - [ ] Generate new PDFs
         - Ensure [fonts](https://brand.publiccode.net/typography/) are installed
         - Serve html content with `script/serve.sh`
         - Optionally, for a visual pre-check, navigate to http://127.0.0.1:4000/ in a browser
         - In a separate terminal than `script/serve.sh`, generate `standard.pdf` and `standard-cover.pdf` with `script/pdf.sh`
         - Rename `standard.pdf` to standard-for-public-code-$MAJOR.$MINOR.$PATCH.pdf`
-4. Create GitHub release with the release notes and version number
-    - [ ] `git tag $MAJOR.$MINOR.$PATCH`
-    - [ ] `git push --tags`
-    - [ ] From https://github.com/publiccodenet/standard/tags select "create release"
-        - Title the release
-        - Add changelog bullets
+    - [ ] Add PDF to release
+        - In a browser navigate to the release and "edit"
         - Drag-and-drop the generated .pdf into the assets
-5. Update 'develop' with a merge from 'main'
-6. [Send the files for print to the printer](printing.md)
+6. Update 'develop' with a merge from 'main'
+7. [Send the files for print to the printer](printing.md)
     - [ ] Cover file
     - [ ] Inside pages PDF


### PR DESCRIPTION
Because the Jekyll theme populates the version and PDF links from the latest
release, we must create the tag and the release prior to generating the PDF.

Also, in order for the correct version to show on the website, we must trigger
a rebuild, after we have created the release, thus we merge an empty commit to
the main branch after we have created the release.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

-----
[View rendered docs/releasing.md](https://github.com/publiccodenet/standard/blob/update-release-steps-030/docs/releasing.md)