### PR TITLE
Git ignore the "vendor/" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 _site
 standard.pdf
 standard-cover.pdf
+vendor/


### PR DESCRIPTION
The vendor/ directory is typically where bundle installs gems