### PR TITLE
Always set PAGES_REPO_NWO in jekyll scripts

### DIFF
--- a/script/serve.sh
+++ b/script/serve.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# jekyll build defaults to "origin" unless PAGES_REPO_NWO is set
-# if there is no "origin" branch and PAGES_REPO_NWO is not set
-# then default to publiccodenet/standard
-if [ "_$(git remote | grep origin)_" != "_origin_" ] &&
-   [ "_${PAGES_REPO_NWO}_" == "__" ]; then
+# if PAGES_REPO_NWO is not set then default to publiccodenet/standard
+# (jekyll defaults to "origin" if a remote of that name exists,
+# which makes sense for a true fork, but not for most contributors)
+if [ "_${PAGES_REPO_NWO}_" == "__" ]; then
 export PAGES_REPO_NWO=publiccodenet/standard
 fi
 

--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# jekyll build defaults to "origin" unless PAGES_REPO_NWO is set
-# if there is no "origin" branch and PAGES_REPO_NWO is not set
-# then default to publiccodenet/standard
-if [ "_$(git remote | grep origin)_" != "_origin_" ] &&
-   [ "_${PAGES_REPO_NWO}_" == "__" ]; then
+# if PAGES_REPO_NWO is not set then default to publiccodenet/standard
+# (jekyll defaults to "origin" if a remote of that name exists,
+# which makes sense for a true fork, but not for most contributors)
+if [ "_${PAGES_REPO_NWO}_" == "__" ]; then
 export PAGES_REPO_NWO=publiccodenet/standard
 fi
 

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# jekyll build defaults to "origin" unless PAGES_REPO_NWO is set
-# if there is no "origin" branch and PAGES_REPO_NWO is not set
-# then default to publiccodenet/standard
-if [ "_$(git remote | grep origin)_" != "_origin_" ] &&
-   [ "_${PAGES_REPO_NWO}_" == "__" ]; then
+# if PAGES_REPO_NWO is not set then default to publiccodenet/standard
+# (jekyll defaults to "origin" if a remote of that name exists,
+# which makes sense for a true fork, but not for most contributors)
+if [ "_${PAGES_REPO_NWO}_" == "__" ]; then
 export PAGES_REPO_NWO=publiccodenet/standard
 fi
 


### PR DESCRIPTION
If PAGES_REPO_NWO is not set, jekyll defaults to "origin" if a remote
of that name exists, which causes link-check tests to fail with 404 for
a contributor who is not hosting a true fork. Thus if it is not set
on purpose by the caller, assume the intent is to contribute upstream
to the publiccodenet/standard repository.