### PR TITLE
Add archive URLs step to releasing

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,6 +19,7 @@
         - Reviewers will create issues for shortcomings found which would not prevent release
         - If needed for release, reviewers may create PRs to resolve issues
         - Re-request reviews if additional PRs are merged into release branch
+    - [ ] Run the to-archive-org.sh script
     - [ ] Once reviews are complete, merge to 'main'
 4. Create GitHub release with the release notes and version number
     - [ ] Switch to the 'main' branch, `git pull` and `git status`

--- a/script/to-archive-org.sh
+++ b/script/to-archive-org.sh
@@ -27,18 +27,22 @@ for FILE in $(git ls-tree -r --name-only $BRANCH_NAME); do
 done
 
 cat urls.txt | cut -f1 -d'#' | sort -u > urls-sorted.txt
+URLS_TOTAL=$(wc -l urls-sorted.txt | cut -f1 -d' ')
 
 # cat urls-sorted.txt
 
 echo "sending to the wayback machine ..."
 MAX_PER_MINUTE=5
 PAUSE_TIME=$(( 1 + (60 / $MAX_PER_MINUTE) ))
+URLS_COUNT=0
 for URL in $(cat urls-sorted.txt); do
 	echo sleeping for $PAUSE_TIME ....
 	sleep $PAUSE_TIME
 	# $ sudo apt-get install gridsite-clients
 	ENCODED=`urlencode $URL`
 	echo ""
+	URLS_COUNT=$(( $URLS_COUNT + 1 ))
+	echo "$URLS_COUNT of $URLS_TOTAL"
 	echo URL: $URL
 	echo encoded: $ENCODED
 	ARC_ORG_URL=https://web.archive.org/save/$ENCODED

--- a/script/to-archive-org.sh
+++ b/script/to-archive-org.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# to-archive-org.sh : send referenced URLs to the wayback machine
+# Copyright (C) 2020 Eric Herman <eric@freesa.org>
+
+# TODO FIXXXME: use something better than bash
+
+rm -f urls.txt
+
+# find . -type f -name '*.md' -print0 |
+# while IFS= read -r -d '' FILE; do
+
+BRANCH_NAME=$(git branch | grep \* | cut -d ' ' -f2)
+for FILE in $(git ls-tree -r --name-only $BRANCH_NAME); do
+	# URLs inside parens
+	grep '(http[s]\?:' "$FILE" \
+		| sed -e's/.*[(]\(http[s]*:[^)]*\).*/\1/' \
+		>> urls.txt
+	# URLs inside angle brackets
+	grep '<http[s]\?:' "$FILE" \
+		| sed -e's/.*<\(http[s]*:[^>]*\).*/\1/' \
+		>> urls.txt
+	# URLs inside double-quotes
+	grep '"http[s]\?:' "$FILE" \
+		| sed -e's/.*"\(http[s]*:[^"]*\).*/\1/' \
+		>> urls.txt
+done
+
+cat urls.txt | cut -f1 -d'#' | sort -u > urls-sorted.txt
+
+# cat urls-sorted.txt
+
+echo "sending to the wayback machine ..."
+MAX_PER_MINUTE=5
+PAUSE_TIME=$(( 1 + (60 / $MAX_PER_MINUTE) ))
+for URL in $(cat urls-sorted.txt); do
+	echo sleeping for $PAUSE_TIME ....
+	sleep $PAUSE_TIME
+	# $ sudo apt-get install gridsite-clients
+	ENCODED=`urlencode $URL`
+	echo ""
+	echo URL: $URL
+	echo encoded: $ENCODED
+	ARC_ORG_URL=https://web.archive.org/save/$ENCODED
+	# wget  --post-data "url=$URL" https://web.archive.org/save
+	wget \
+		--user-agent="foundation-for-public-code-url-archiver" \
+		$ARC_ORG_URL
+done
+echo "done"

--- a/script/to-archive-org.sh
+++ b/script/to-archive-org.sh
@@ -31,8 +31,9 @@ URLS_TOTAL=$(wc -l urls-sorted.txt | cut -f1 -d' ')
 
 # cat urls-sorted.txt
 
-echo "sending to the wayback machine ..."
 MAX_PER_MINUTE=5
+echo "sending $URLS_TOTAL URLs to the wayback machine,"
+echo "        throttled to $MAX_PER_MINUTE per minute..."
 PAUSE_TIME=$(( 1 + (60 / $MAX_PER_MINUTE) ))
 URLS_COUNT=0
 for URL in $(cat urls-sorted.txt); do


### PR DESCRIPTION
We run this by hand in order to avoid blocking merges to main on a very
slow script, given we can only submit 5 URLs per minute.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

Fixes #275 

-----
[View rendered docs/releasing.md](https://github.com/ericherman/standard-for-public-code/blob/archive-urls/docs/releasing.md)