### PR TITLE
Add SPDX-License-Identifier: CC0-1.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,8 @@
 # Authors
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 [The Foundation for Public Code](https://publiccode.net)
 
 * Arnout Schuijff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 ## Version 0.3.0
 
 May 23rd 2022: 🗎 the tenth draft strengthens documentation and localization.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to this standard
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 🙇‍♀️ Thank you for contributing!
 
 We understand that a standard like this can only be set in collaboration with as many public technologists, policy makers and interested folk as possible. Thus we appreciate your input, enjoy feedback and welcome improvements to this project and are very open to collaboration.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,8 @@
 # Governance
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 This standard lies at the core of the codebase stewardship provided by the [Foundation for Public Code](https://publiccode.net/). We decide if a codebase is ready for community co-development based on this document.
 
 The standard is maintained by Foundation for Public Code staff.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Standard for Public Code
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 ![version 0.3.0](https://img.shields.io/badge/version-0.3.0-red.svg)
 ![Test](https://github.com/publiccodenet/standard/workflows/Test/badge.svg)
 ![Scheduled link check](https://github.com/publiccodenet/standard/workflows/Scheduled%20link%20check/badge.svg)

--- a/_includes/badges.html
+++ b/_includes/badges.html
@@ -1,1 +1,3 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2021 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 <p><a href="https://digitalpublicgoods.net/registry/standard-for-public-code.html"><img src="/assets/dpg-badge.svg" width="92" height="46" alt="Digital Public Goods approval" /></a></p>

--- a/_includes/translations.html
+++ b/_includes/translations.html
@@ -1,1 +1,3 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2022 by The Foundation for Public Code <info@publiccode.net> -->
 <p><a href="https://publiccodenet.github.io/community-translations-standard/">Translations</a> of the Standard for Public Code</p>

--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -1,8 +1,10 @@
 ---
 order: 2
 ---
-
 # Bundle policy and source code
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/code-in-the-open.md
+++ b/criteria/code-in-the-open.md
@@ -1,8 +1,10 @@
 ---
 order: 1
 ---
-
 # Code in the open
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -1,8 +1,10 @@
 ---
 order: 12
 ---
-
 # Use continuous integration
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -5,6 +5,9 @@ redirect_from:
 ---
 # Document codebase maturity
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 ## Requirements
 
 * A codebase MUST be versioned.

--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -1,8 +1,10 @@
 ---
 order: 8
 ---
-
 # Document codebase objectives
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -3,6 +3,9 @@ order: 9
 ---
 # Document the code
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 ## Requirements
 
 * All of the functionality of the codebase, policy as well as source, MUST be described in language clearly understandable for those that understand the purpose of the code.

--- a/criteria/index.md
+++ b/criteria/index.md
@@ -1,5 +1,8 @@
 # Criteria
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 {% assign sorted = site.pages | sort:"order" %}
 
 {% for page in sorted %}{% if page.dir == "/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -1,8 +1,10 @@
 ---
 order: 5
 ---
-
 # Make contributing easy
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/open-licenses.md
+++ b/criteria/open-licenses.md
@@ -1,8 +1,10 @@
 ---
 order: 13
 ---
-
 # Publish with an open license
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/open-standards.md
+++ b/criteria/open-standards.md
@@ -1,8 +1,10 @@
 ---
 order: 11
 ---
-
 # Use open standards
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -1,8 +1,10 @@
 ---
 order: 4
 ---
-
 # Welcome contributors
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/require-review.md
+++ b/criteria/require-review.md
@@ -1,8 +1,10 @@
 ---
 order: 7
 ---
-
 # Require review of contributions
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/reusable-and-portable-codebases.md
+++ b/criteria/reusable-and-portable-codebases.md
@@ -1,8 +1,10 @@
 ---
 order: 3
 ---
-
 # Create reusable and portable code
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/style.md
+++ b/criteria/style.md
@@ -1,8 +1,10 @@
 ---
 order: 14
 ---
-
 # Use a coherent style
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -1,8 +1,10 @@
 ---
 order: 10
 ---
-
 # Use plain English
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -1,8 +1,10 @@
 ---
 order: 6
 ---
-
 # Maintain version control
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 
 ## Requirements
 

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2021 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 # Printing
 
 The printed Standard for Public Code is printed by Reclameland. This guide tries to provide the relevant information to print it there or somewhere else.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2021 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 # Releasing a new version of the Standard for public code
 
 1. Review state of the 'develop' branch

--- a/glossary.md
+++ b/glossary.md
@@ -1,5 +1,8 @@
 # Glossary
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 ## Code
 
 Any explicitly described system of rules. This includes laws, policy and ordinances, as well as source code that is used to build software. Both of these are rules, some executed by humans and others by machines.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,8 @@
 # Contents
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 Welcome to the Standard for Public Code.
 
 We define ‘public code’ as open source software developed by public organizations, together with the policy and guidance needed for collaboration and reuse.

--- a/introduction.md
+++ b/introduction.md
@@ -1,5 +1,8 @@
 # Introduction
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 The Standard for Public Code is a set of criteria that supports public organizations in developing and maintaining software and policy together.
 
 Anyone developing software or policy for a public purpose can use this standard to work towards higher quality public services that are more cost effective, with less risk and more control.

--- a/print-cover.html
+++ b/print-cover.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2021 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 ---
 ---
 

--- a/print.html
+++ b/print.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
 ---
 ---
 

--- a/readers-guide.md
+++ b/readers-guide.md
@@ -1,5 +1,8 @@
 # Readers guide
 
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- written in 2019 - 2022 by The Foundation for Public Code <info@publiccode.net> -->
+
 The Standard describes a number of criteria.
 All criteria have consistent sections that make it clear how to create great public code.
 Below is a brief explanation of each of these sections and how they are used within the criteria of the Standard.


### PR DESCRIPTION
In order to work with the site building, the SPDX can not be the first line of markdown files with "front matter".

Fixes #648

-----
[View rendered AUTHORS.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/AUTHORS.md)
[View rendered CHANGELOG.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/CHANGELOG.md)
[View rendered CONTRIBUTING.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/CONTRIBUTING.md)
[View rendered GOVERNANCE.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/GOVERNANCE.md)
[View rendered README.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/README.md)
[View rendered criteria/bundle-policy-and-code.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/bundle-policy-and-code.md)
[View rendered criteria/code-in-the-open.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/code-in-the-open.md)
[View rendered criteria/continuous-integration.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/continuous-integration.md)
[View rendered criteria/document-maturity.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/document-maturity.md)
[View rendered criteria/document-objectives.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/document-objectives.md)
[View rendered criteria/documenting.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/documenting.md)
[View rendered criteria/index.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/index.md)
[View rendered criteria/make-contributing-easy.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/make-contributing-easy.md)
[View rendered criteria/open-licenses.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/open-licenses.md)
[View rendered criteria/open-standards.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/open-standards.md)
[View rendered criteria/open-to-contributions.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/open-to-contributions.md)
[View rendered criteria/require-review.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/require-review.md)
[View rendered criteria/reusable-and-portable-codebases.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/reusable-and-portable-codebases.md)
[View rendered criteria/style.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/style.md)
[View rendered criteria/understandable-english-first.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/understandable-english-first.md)
[View rendered criteria/version-control-and-history.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/criteria/version-control-and-history.md)
[View rendered docs/printing.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/docs/printing.md)
[View rendered docs/releasing.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/docs/releasing.md)
[View rendered glossary.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/glossary.md)
[View rendered index.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/index.md)
[View rendered introduction.md](https://github.com/ericherman/standard-for-public-code/blob/add-cc0-to-content/introduction.md)