### PR TITLE
Pin html proofer to ~>3.19 to unbreak build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+gem 'html-proofer', '~>3.19'
 gem 'mdl'


### PR DESCRIPTION
Newer html-proofer (4.0.1) fails with:

```
htmlproofer 4.0.1 | Error:  invalid option: --typhoeus-config
```

and complains about some of the jekyll generated html

https://github.com/publiccodenet/standard/actions/runs/2660759422