### PR TITLE
Allow CC0-1.0 in "Publish with an open license"

### DIFF
--- a/criteria/open-licenses.md
+++ b/criteria/open-licenses.md
@@ -9,7 +9,7 @@ order: 13
 ## Requirements
 
 * All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable.
-* Software source code MUST be licensed under an [OSI-approved open source license](https://opensource.org/licenses/category).
+* Software source code MUST be licensed under an [OSI-approved or FSF Free/Libre license](https://spdx.org/licenses/).
 * All code MUST be published with a license file.
 * Contributors MUST NOT be required to transfer copyright of their contributions to the codebase.
 * All source code files in the codebase SHOULD include a copyright notice and a license header that are machine-readable.
@@ -26,7 +26,7 @@ order: 13
 ## How to test
 
 * There is at least 1 license file present in the codebase, usually called `license`.
-* The license for the source code is on the [OSI-approved Open Source license list](https://opensource.org/licenses/category) and the license for documentation is [conformant to the Open Definition](https://opendefinition.org/licenses/).
+* The license for the source code is on the [OSI-approved or FSF Free/Libre license list](https://spdx.org/licenses/) and the license for documentation is [conformant to the Open Definition](https://opendefinition.org/licenses/).
 * Add machine-readable license checking to the codebase continuous integration tests.
 
 ## Policy makers: what you need to do


### PR DESCRIPTION
In preparing our upcoming `moda.gov.tw` government website for release as public code, we've found that while LibreJS considers HTML/JavaScript code marked `CC0-1.0` as libre, the license is not yet [OSI-approved](https://spdx.org/licenses/), running counter to this requirement:

> Software source code MUST be licensed under an [OSI-approved open source license](https://opensource.org/licenses/category).

Practically, we can accept `CC0-1.0` via reference to FSF Free/Libre: 

> Software source code MUST be licensed under an [OSI-approved or FSF Free/Libre license](https://spdx.org/licenses/).

Compared to alternatives such as `0BSD`, `CC0-1.0` has seen more use in Taiwan, partly due to its popularity as an [Open Data license](https://data.gov.tw/en/licenses).

-----
[View rendered criteria/open-licenses.md](https://github.com/audreyt/standard/blob/patch-1/criteria/open-licenses.md)