### PR TITLE
Clarify code for software or policy

### DIFF
--- a/criteria/code-in-the-open.md
+++ b/criteria/code-in-the-open.md
@@ -8,7 +8,8 @@ order: 1
 
 ## Requirements
 
-* All source code for any policy and software in use (unless used for fraud detection) MUST be published and publicly accessible.
+* All source code for any policy in use (unless used for fraud detection) MUST be published and publicly accessible.
+* All source code for any software in use (unless used for fraud detection) MUST be published and publicly accessible.
 * Contributors MUST NOT upload sensitive information regarding users, their organization or third parties to the repository.
 * Any source code not currently in use (such as new versions, proposals or older versions) SHOULD be published.
 * The codebase MAY provide the general public with insight into which source code or policy underpins any specific interaction they have with an organization.


### PR DESCRIPTION
Split into two nearly identical requirements.

Fixes #600

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>

-----
[View rendered criteria/code-in-the-open.md](https://github.com/publiccodenet/standard/blob/split-policy-code-600/criteria/code-in-the-open.md)