### PR TITLE
Remove redundant requirement

### DIFF
--- a/criteria/bundle-policy-and-code.md
+++ b/criteria/bundle-policy-and-code.md
@@ -10,7 +10,6 @@ order: 2
 
 * A codebase MUST include the policy that the source code is based on.
 * A codebase MUST include all source code that the policy is based on, unless used for fraud detection.
-* All policy and source code that the codebase is based on MUST be documented, reusable and portable.
 * Policy SHOULD be provided in machine readable and unambiguous formats.
 * Continuous integration tests SHOULD validate that the source code and the policy are executed coherently.
 


### PR DESCRIPTION
fixes: #645 and fixes #669 

We discussed splitting the requirement:

> * All policy and source code that the codebase is based on MUST be
>   documented, reusable and portable.

in to perhaps as many as six separate requirements, as it has two
subjects (policy and source code) and three states (documented,
reusable, and portable). However we concluded that for source code these
are all clearly specified as criteria in their own right. For policy,
documented is clearly covered by another criterion, and "reusable and
portable" is far less meaningful. As such, we do not see how this adds
more value than confusion.

Co-authored-by: Jan Ainali <jan@publiccode.net>

-----
[View rendered criteria/bundle-policy-and-code.md](https://github.com/publiccodenet/standard/blob/remove-duplicate-requirement-645/criteria/bundle-policy-and-code.md)