### PR TITLE
Change MAY to OPTIONAL

### DIFF
--- a/criteria/code-in-the-open.md
+++ b/criteria/code-in-the-open.md
@@ -12,7 +12,7 @@ order: 1
 * All source code for any software in use (unless used for fraud detection) MUST be published and publicly accessible.
 * Contributors MUST NOT upload sensitive information regarding users, their organization or third parties to the repository.
 * Any source code not currently in use (such as new versions, proposals or older versions) SHOULD be published.
-* The codebase MAY provide the general public with insight into which source code or policy underpins any specific interaction they have with an organization.
+* Documenting which source code or policy underpins any specific interaction the general public may have with an organization is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/continuous-integration.md
+++ b/criteria/continuous-integration.md
@@ -14,8 +14,8 @@ order: 12
 * The codebase MUST have active contributors.
 * The codebase guidelines SHOULD state that each contribution should focus on a single issue.
 * Source code test and documentation coverage SHOULD be monitored.
-* Policy and documentation MAY have testing for consistency with the source and vice versa.
-* Policy and documentation MAY have testing for style and broken links.
+* Testing policy and documentation for consistency with the source and vice versa is OPTIONAL.
+* Testing policy and documentation for style and broken links is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/document-objectives.md
+++ b/criteria/document-objectives.md
@@ -10,7 +10,7 @@ order: 8
 
 * The codebase MUST contain documentation of its objectives, like a mission and goal statement, that is understandable by developers and designers so that they can use or contribute to the codebase.
 * Codebase documentation SHOULD clearly describe the connections between policy objectives and codebase objectives.
-* The codebase MAY contain documentation of its objectives for the general public.
+* Documenting the objectives of the codebase for the general public is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/documenting.md
+++ b/criteria/documenting.md
@@ -16,8 +16,8 @@ order: 9
 * The documentation of the codebase SHOULD contain examples for all functionality.
 * The documentation SHOULD describe the key components or modules of the codebase and their relationships, for example as a high level architectural diagram.
 * There SHOULD be continuous integration tests for the quality of the documentation.
-* The documentation of the codebase MAY contain examples that make users want to immediately start using the codebase.
-* The code MAY be tested by using examples in the documentation.
+* Including examples that make users want to immediately start using the codebase in the documentation of the codebase is OPTIONAL.
+* Testing the code by using examples in the documentation is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/open-licenses.md
+++ b/criteria/open-licenses.md
@@ -13,7 +13,7 @@ order: 13
 * All code MUST be published with a license file.
 * Contributors MUST NOT be required to transfer copyright of their contributions to the codebase.
 * All source code files in the codebase SHOULD include a copyright notice and a license header that are machine-readable.
-* Codebases MAY have multiple licenses for different types of code and documentation.
+* Having multiple licenses for different types of code and documentation is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/open-to-contributions.md
+++ b/criteria/open-to-contributions.md
@@ -14,7 +14,7 @@ order: 4
 * The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
 * The codebase SHOULD have a publicly available roadmap.
 * The codebase SHOULD publish codebase activity statistics.
-* The codebase MAY include a code of conduct for contributors.
+* Including a code of conduct for contributors in the codebase is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/require-review.md
+++ b/criteria/require-review.md
@@ -16,7 +16,7 @@ order: 7
 * Contributions SHOULD be reviewed by someone in a different context than the contributor.
 * Version control systems SHOULD NOT accept non-reviewed contributions in release versions.
 * Reviews SHOULD happen within two business days.
-* Reviews MAY be performed by multiple reviewers.
+* Performing reviews by multiple reviewers is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/style.md
+++ b/criteria/style.md
@@ -11,7 +11,7 @@ order: 15
 * Contributions MUST adhere to either a coding or writing style guide, either the codebase community's own or an existing one that is advertised in or part of the codebase.
 * Contributions SHOULD pass automated tests on style.
 * The codebase SHOULD include inline comments and documentation for non-trivial sections.
-* The style guide MAY include sections on [understandable English](understandable-english-first.md).
+* Including sections on [understandable English](understandable-english-first.md) in the style guide is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/understandable-english-first.md
+++ b/criteria/understandable-english-first.md
@@ -15,7 +15,7 @@ order: 10
 * There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
 * The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.
 * Documentation SHOULD aim for a lower secondary education reading level, as recommended by the [Web Content Accessibility Guidelines 2](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable).
-* Any code, documentation or tests MAY have a translation.
+* Providing a translation of any code, documentation or tests is OPTIONAL.
 
 ## Why this is important
 

--- a/criteria/version-control-and-history.md
+++ b/criteria/version-control-and-history.md
@@ -16,7 +16,7 @@ order: 6
 * Contributors SHOULD group relevant changes in commits.
 * Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels.
 * Contributors SHOULD prefer file formats where the changes within the files can be easily viewed and understood in the version control system.
-* Contributors MAY sign their commits and provide an email address, so that future contributors are able to contact past contributors with questions about their work.
+* It is OPTIONAL for contributors to sign their commits and provide an email address, so that future contributors are able to contact past contributors with questions about their work.
 
 ## Why this is important
 


### PR DESCRIPTION
This reflects the behavior we want to encourage better.
I kept the MAY in Use open standards since that is a permitting one.

Fixes #668

-----
[View rendered criteria/code-in-the-open.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/code-in-the-open.md)
[View rendered criteria/continuous-integration.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/continuous-integration.md)
[View rendered criteria/document-objectives.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/document-objectives.md)
[View rendered criteria/documenting.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/documenting.md)
[View rendered criteria/open-licenses.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/open-licenses.md)
[View rendered criteria/open-to-contributions.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/open-to-contributions.md)
[View rendered criteria/require-review.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/require-review.md)
[View rendered criteria/style.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/style.md)
[View rendered criteria/understandable-english-first.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/understandable-english-first.md)
[View rendered criteria/version-control-and-history.md](https://github.com/publiccodenet/standard/blob/may-to-optional/criteria/version-control-and-history.md)