### PR TITLE
Rewrite MAY as MUST NOT in "Use open standards"

### DIFF
--- a/criteria/open-standards.md
+++ b/criteria/open-standards.md
@@ -11,9 +11,9 @@ order: 11
 * For features of a codebase that facilitate the exchange of data the codebase MUST use an open standard that meets the [Open Source Initiative Open Standard Requirements](https://opensource.org/osr).
 * Any non-open standards used MUST be recorded clearly as such in the documentation.
 * Any standard chosen for use within the codebase MUST be listed in the documentation with a link to where it is available.
+* Any non-open standards chosen for use within the codebase MUST NOT hinder collaboration and reuse.
 * If no existing open standard is available, effort SHOULD be put into developing one.
 * Standards that are machine testable SHOULD be preferred over those that are not.
-* Functionality using features from a standard that is not an open standard MAY be provided if necessary, but only in addition to compliant features.
 
 ## Why this is important
 


### PR DESCRIPTION
Rather than state a requirement permissively when it is not desired,
change the phrasing to constrain/limit undesirable actions.

fixes: #681

-----
[View rendered criteria/open-standards.md](https://github.com/publiccodenet/standard/blob/open-standards-may-to-must-not/criteria/open-standards.md)