### PR TITLE
Fix colliding links in pdf

### DIFF
--- a/criteria/findability.md
+++ b/criteria/findability.md
@@ -13,7 +13,7 @@ order: 14
 * The codebase MUST be findable using a search engine by codebase name.
 * Maintainers SHOULD submit the codebase to relevant software catalogs.
 * The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).
-* The codebase SHOULD have a unique and persistent identifier, such as a [Wikidata item](https://www.wikidata.org/wiki/Wikidata:Introduction) or [FSF software directory listing](https://directory.fsf.org/wiki/Main_Page), where the entry mentions the major contributors, repository location and website.
+* The codebase SHOULD have a unique and persistent identifier, such as a Wikidata item or [FSF software directory listing](https://directory.fsf.org/wiki/Main_Page), where the entry mentions the major contributors, repository location and website.
 * The codebase SHOULD include a machine-readable metadata description, for example in a [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) file.
 * A dedicated domain name for the codebase is OPTIONAL.
 * Regular presentations at conferences by the community is OPTIONAL.
@@ -57,4 +57,5 @@ Check that the codebase appears in the first set of results on more than one maj
 
 ## Further reading
 
+* [Introduction to Wikidata](https://www.wikidata.org/wiki/Wikidata:Introduction) by the Wikidata community.
 * The [FAIR Guiding Principles for scientific data management and stewardship](https://www.go-fair.org/fair-principles/) by the GO FAIR International Support and Coordination Office provide a nice list of attributes that make (meta)data more machine actionable (and hence more findable). Some of these apply directly to codebases, while others may provoke exploration into what the codebase equivalent would be.

--- a/criteria/findability.md
+++ b/criteria/findability.md
@@ -13,7 +13,7 @@ order: 14
 * The codebase MUST be findable using a search engine by codebase name.
 * Maintainers SHOULD submit the codebase to relevant software catalogs.
 * The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).
-* The codebase SHOULD have a unique and persistent identifier, such as a Wikidata item or [FSF software directory listing](https://directory.fsf.org/wiki/Main_Page), where the entry mentions the major contributors, repository location and website.
+* The codebase SHOULD have a unique and persistent identifier where the entry mentions the major contributors, repository location and website.
 * The codebase SHOULD include a machine-readable metadata description, for example in a [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) file.
 * A dedicated domain name for the codebase is OPTIONAL.
 * Regular presentations at conferences by the community is OPTIONAL.
@@ -23,7 +23,7 @@ order: 14
 * Proactiveness is needed; just publishing a codebase and hoping it's found doesn't work.
 * A metadata description file increases discoverability.
 * The more findable a codebase is, the more potential new collaborators will find it.
-* By having well-written metadata containing a unique and persistent identifer, and thus being part of the semantic web, it will be easier for other people to refer, cite, disambiguate and discover the codebase through third party tools.
+* By having well-written metadata containing a unique and persistent identifer, such as a Wikidata item or FSF software directory listing, and thus being part of the semantic web, it will be easier for other people to refer, cite, disambiguate and discover the codebase through third party tools.
 
 ## What this does not do
 
@@ -58,4 +58,5 @@ Check that the codebase appears in the first set of results on more than one maj
 ## Further reading
 
 * [Introduction to Wikidata](https://www.wikidata.org/wiki/Wikidata:Introduction) by the Wikidata community.
+* [FSF software directory listing](https://directory.fsf.org/wiki/Main_Page) by the Free Softare Foundation.
 * The [FAIR Guiding Principles for scientific data management and stewardship](https://www.go-fair.org/fair-principles/) by the GO FAIR International Support and Coordination Office provide a nice list of attributes that make (meta)data more machine actionable (and hence more findable). Some of these apply directly to codebases, while others may provoke exploration into what the codebase equivalent would be.


### PR DESCRIPTION
The Wikidata and FSF links collides in the pdf, so move the introduction down to further reading which also works since it is a link to wider information than just about the item.

-----
[View rendered criteria/findability.md](https://github.com/publiccodenet/standard/blob/link-line-fix/criteria/findability.md)