### PR TITLE
Regular update of roadmap in pruning session

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,16 +9,11 @@ Codebase stewards review the roadmap monthly as part of our [backlog pruning ses
 
 ## Current work
 
-* Demonstrate good example codebases of each criterion (especially Bundle policy and code)
-* Clarify computer code vs policy text in requirements
-* Remove multiple bullet point requirements
-* Fold in feedback e.g.: findability, modularity
 * Work through the issue backlog
 * Separate executive summary
 
 ## Near term
 
-* Links to examples of Standard-compliant implementations
 * Put "Why is this important" before requirements
 * Possibly: add in the illustrations for each criterion
 * As far as possible, make the standard Standard-compliant


### PR DESCRIPTION
Points done in release 0.4.0 removed.
Points related to implementation guide removed.

-----
[View rendered docs/roadmap.md](https://github.com/publiccodenet/standard/blob/roadmap-update-sep-22/docs/roadmap.md)