### PR TITLE
Label maturity as beta instead of draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The standard lives at [standard.publiccode.net](https://standard.publiccode.net/
 
 ## Help improve this standard
 
-We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop it. 😊 Get started by reading our [contributors guide](CONTRIBUTING.md). Since it is such a core document we will accept contributions when they add significant value. We've described how we govern the standard in the [governance statement](GOVERNANCE.md).
+We are looking for people like you to [contribute](CONTRIBUTING.md) to this project, currently in beta, by suggesting improvements and helping develop it. 😊 Get started by reading our [contributors guide](CONTRIBUTING.md). Since it is such a core document we will accept contributions when they add significant value. We've described how we govern the standard in the [governance statement](GOVERNANCE.md).
 
 Please note that this project is released with a [code of conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Please be lovely to all other community members.
 

--- a/docs/standard-for-public-code.md
+++ b/docs/standard-for-public-code.md
@@ -214,11 +214,11 @@ Including sections on [understandable English](https://standard.publiccode.net/c
 
 ## [Document codebase maturity](https://standard.publiccode.net/criteria/document-maturity.html)
 
-- [ ] criterion met.
+- [x] criterion met.
 
 Requirement | meets | links and notes
 -----|-----|-----
 A codebase MUST be versioned. | Ok |
 A codebase that is ready to use MUST only depend on other codebases that are also ready to use. | Ok |
-A codebase that is not yet ready to use MUST have one of the labels: prototype, alpha, beta or pre-release version. |  | labled as "draft", consider adding "beta" label?
+A codebase that is not yet ready to use MUST have one of the labels: prototype, alpha, beta or pre-release version. | Ok |
 A codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`. | Ok | [CHANGELOG](https://github.com/publiccodenet/standard/blob/develop/CHANGELOG.md)

--- a/index.md
+++ b/index.md
@@ -37,3 +37,5 @@ There are also unofficial [community translations of the Standard](https://publi
 * [Governance](GOVERNANCE.md)
 * [Version history](CHANGELOG.md)
 * [License](LICENSE.md)
+
+The Standard for Public Code is currently in beta.

--- a/print-cover.html
+++ b/print-cover.html
@@ -253,7 +253,7 @@
       <img src="assets/hands-shake.svg" alt="hands shaking">
 
       <div id="version-info">
-        <p><strong>Draft</strong><br/>Version {{ site.version }}</p>
+        <p><strong>Beta</strong><br/>Version {{ site.version }}</p>
         <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0" height="46"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
         <p>https://standard.publiccode.net/</p>
       </div>

--- a/print.html
+++ b/print.html
@@ -283,7 +283,7 @@
 
     <img src="assets/hands-shake.svg" alt="hands shaking">
 
-    <p><strong>Draft</strong><br/>Version {{ site.version }}</p>
+    <p><strong>Beta</strong><br/>Version {{ site.version }}</p>
     <p><img src="/assets/cc-zero-badge.svg" alt="Licensed CC0" height="46"> <img src="/assets/dpg-badge.svg" alt="Digital Public Goods approval badge" width="92" height="46"></p>
     <p>github.com/publiccodenet/standard</p>
   </article>


### PR DESCRIPTION
Fixes #704

Added extra documentation so that it also shows on the web and in the repository.

-----
[View rendered README.md](https://github.com/publiccodenet/standard/blob/draft-to-beta/README.md)
[View rendered docs/standard-for-public-code.md](https://github.com/publiccodenet/standard/blob/draft-to-beta/docs/standard-for-public-code.md)
[View rendered index.md](https://github.com/publiccodenet/standard/blob/draft-to-beta/index.md)