### PR TITLE
Skip check of opensource.org links

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -23,10 +23,13 @@ bundle exec jekyll build
 # * github.com/foo/edit/ : may reference yet-to-exist pages
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
+# * opensource.org : gives "failed: 503 No error" when run as GitHub workflow
+#
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
 ,/plausible\.io\/js\/plausible\.js/\
+,/opensource\.org/\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
The linkchecks work reliably from my desktop, but the GitHub workflow has been failing for ages:

```
- ./_site/criteria/open-licenses.html
  *  External link https://opensource.org/osd failed: 503 No error
- ./_site/docs/review-template.html
  *  External link https://opensource.org/osr failed: 503 No error
- ./_site/print.html
  *  External link https://opensource.org/osd-annotated failed: 503 No error
```

from:
https://github.com/publiccodenet/standard/actions/runs/3231838374/jobs/5291787221 and the dozens prior.