### PR TITLE
Skip reclameland.nl in link check

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -24,12 +24,14 @@ bundle exec jekyll build
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * opensource.org : gives "failed: 503 No error" when run as GitHub workflow
+# * reclameland.nl : often "failed: 403 No error" when run as GitHub workflow
 #
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
 ,/plausible\.io\/js\/plausible\.js/\
 ,/opensource\.org/\
+,/reclameland\.nl\/drukken\/softcover-boeken/
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
This has been "crying wolf" a lot. It has never failed for me when testing from my machine, or from a cloud machine, yet regularly does so in our nightly link-check.

```
 Checking 149 external links...
- ./_site/docs/printing.html
Ran on 37 files!
  *  External link https://www.reclameland.nl/drukken/softcover-boeken failed: 403 No error
```

https://github.com/publiccodenet/standard/actions/runs/3262272732/jobs/5359108609