### PR TITLE
Focus on ready to use, remove maturity labels with industry misalignment

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,7 @@
 * Marcus Klaas de Vries
 * Mark van der Net, [Gemeente Amsterdam](https://www.amsterdam.nl/en/)
 * Martijn de Waal, [Amsterdam University of Applied Sciences (AUAS)](https://www.amsterdamuas.com/), Faculty of Digital Media and Creative Industries, Lectorate of Play & Civic Media
+* Matti Schneider
 * Mauko Quiroga
 * Maurice Hendriks, Gemeente Amsterdam
 * Maurits van der Schee, Gemeente Amsterdam

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -11,9 +11,11 @@ redirect_from:
 ## Requirements
 
 * The [codebase](../glossary.md#codebase) MUST be versioned.
-* The codebase that is ready to use MUST only depend on other codebases that are also ready to use.
-* The codebase that is not yet ready to use MUST have one of the labels: prototype, alpha, beta or pre-release version.
+* The codebase MUST prominently document whether or not there are versions of the codebase which are ready to use.
+* Codebase versions which are ready to use MUST only depend on versions of other codebases that are also ready to use.
 * The codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`.
+* The method for assigning version identifiers SHOULD be documented.
+* It is OPTIONAL to use semantic versioning.
 
 ## Why this is important
 
@@ -26,9 +28,9 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 ## How to test
 
 * Confirm that the codebase has a strategy for versioning which is documented.
-* Confirm that it is clear where to get the newest version.
-* Confirm that the codebase doesn't depend on any codebases marked with a less mature status.
-* Confirm that the codebase is ready to use or labeled as prototype, alpha, beta or pre-release version.
+* Confirm that it is obvious to policy makers, managers, developers and designers whether the codebase has versions which are ready to use.
+* Confirm that ready to use versions of the codebase do not depend on any versions of other codebases which are not ready to use.
+* Check that the versioning scheme of the codebase is documented and followed.
 * Check that there is a log of changes.
 
 ## Policy makers: what you need to do
@@ -38,22 +40,15 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 
 ## Management: what you need to do
 
-* Make sure that services only rely on codebases of equal or greater maturity than the service. For example, don't use a beta codebase in a production service or a prototype codebase in a beta service.
-* If the codebase is not ready for general use, work with the developers to ensure the codebase is properly labeled:
-  * prototype: to test the look and feel, and to internally prove the concept of the technical possibilities,
-  * alpha: to do guided tests with a limited set of users,
-  * beta: to open up testing to a larger section of the [general public](../glossary.md#general-public), for example to test if the codebase works at scale,
-  * pre-release version: code that is ready to be released but hasn't received formal approval yet.
+* Make sure that services only rely on versions of codebases of equal or greater maturity than the service. For example, don't use a beta version of a codebase in a production service.
 
 ## Developers and designers: what you need to do
 
-* Add a prominent header to every interface that indicates the maturity level of the code.
-* Version all releases.
-* Especially in 'rolling release' scenarios, the version may be automatically derived from the [version control](../glossary.md#version-control) system metadata (for example by using [git describe](https://git-scm.com/docs/git-describe)).
+* Ensure that the codebase versioning approach is followed for all releases.
 
 ## Further reading
 
+* [Semantic Versioning Specification](https://semver.org/) used by many codebases to label versions.
+* [Software release life cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle)
 * [Service Design and Delivery Process](https://www.dta.gov.au/help-and-advice/build-and-improve-services/service-design-and-delivery-process) by the Australian Digital Transformation Agency.
 * [Service Manual on Agile Delivery](https://www.gov.uk/service-manual/agile-delivery) by the UK Government Digital Service.
-* [Semantic Versioning Specification](https://semver.org/) used by many codebases to label versions.
-* [What are the Discovery, Alpha, Beta and Live stages in developing a service? [Video 0'0"59]](https://www.youtube.com/watch?v=_cyI7DMhgYc) by the UK Government Digital Service.


### PR DESCRIPTION
Fixes #708
    
Clearly document whether or not a codebase has versions which are ready to use.
Maturity applies to versions.
No longer specify version labels.
    
With this change, we no longer have the mismatch between "pre-release" being used widely to indicate any non-stable version and our previous niche usage.
    
Updates Further reading for Document maturity
Removes video about service development, as that is tangential
Re-orders remaining links
    
Co-authored-by: @Ainali
Co-authored-by: @MattiSG

-----
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/lifecycle-labels/criteria/document-maturity.md)
