### PR TITLE
Meets using approve license requirement

### DIFF
--- a/docs/standard-for-public-code.md
+++ b/docs/standard-for-public-code.md
@@ -180,7 +180,7 @@ Testing policy and documentation for style and broken links is OPTIONAL. | Ok |
 Requirement | meets | links and notes
 -----|-----|-----
 All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable. | Ok | [CC 0](https://github.com/publiccodenet/standard/blob/develop/LICENSE)
-Software source code MUST be licensed under an [OSI-approved or FSF Free/Libre license](https://spdx.org/licenses/). |  |
+Software source code MUST be licensed under an [OSI-approved or FSF Free/Libre license](https://spdx.org/licenses/). | Ok | CC 0
 All code MUST be published with a license file. | Ok | CC 0
 Contributors MUST NOT be required to transfer copyright of their contributions to the codebase. | Ok |
 All source code files in the codebase SHOULD include a copyright notice and a license header that are machine-readable. |  | almost all files have SPDX


### PR DESCRIPTION
(since FSF licenses was added)

-----
[View rendered docs/standard-for-public-code.md](https://github.com/publiccodenet/standard/blob/meets-license-choice-requirement/docs/standard-for-public-code.md)