### PR TITLE
Lifecycle version labels

### DIFF
--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -12,7 +12,7 @@ redirect_from:
 
 * A codebase MUST be versioned.
 * A codebase that is ready to use MUST only depend on other codebases that are also ready to use.
-* A codebase that is not yet ready to use MUST have one of the labels: prototype, alpha, beta or pre-release version.
+* A codebase that is not yet ready to use MUST have one of the labels: pre-alpha, alpha, beta or release candidate.
 * A codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`.
 
 ## Why this is important
@@ -28,7 +28,7 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 * Confirm that the codebase has a strategy for versioning which is documented.
 * Confirm that it is clear where to get the newest version.
 * Confirm that the codebase doesn't depend on any codebases marked with a less mature status.
-* Confirm that the codebase is ready to use or labeled as prototype, alpha, beta or pre-release version.
+* Confirm that the codebase is ready to use or labeled as prototype, alpha, beta or release candidate version.
 * Check that there is a log of changes.
 
 ## Policy makers: what you need to do
@@ -40,10 +40,10 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 
 * Make sure that services only rely on codebases of equal or greater maturity than the service. For example, don't use a beta codebase in a production service or a prototype codebase in a beta service.
 * If the codebase is not ready for general use, work with the developers to ensure the codebase is properly labeled:
-  * prototype: to test the look and feel, and to internally prove the concept of the technical possibilities,
+  * pre-alpha: to test the look and feel, and to internally prove the concept of the technical possibilities,
   * alpha: to do guided tests with a limited set of users,
   * beta: to open up testing to a larger section of the general public, for example to test if the codebase works at scale,
-  * pre-release version: code that is ready to be released but hasn't received formal approval yet.
+  * release candidate: code that is ready to be released but hasn't received formal approval yet.
 
 ## Developers and designers: what you need to do
 
@@ -57,3 +57,4 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 * [Service Manual on Agile Delivery](https://www.gov.uk/service-manual/agile-delivery) by the UK Government Digital Service.
 * [Semantic Versioning Specification](https://semver.org/) used by many codebases to label versions.
 * [What are the Discovery, Alpha, Beta and Live stages in developing a service? [Video 0'0"59]](https://www.youtube.com/watch?v=_cyI7DMhgYc) by the UK Government Digital Service.
+* [Software release life cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle)

--- a/criteria/document-maturity.md
+++ b/criteria/document-maturity.md
@@ -11,13 +11,13 @@ redirect_from:
 ## Requirements
 
 * A codebase MUST be versioned.
-* A codebase that is ready to use MUST only depend on other codebases that are also ready to use.
-* A codebase that is not yet ready to use MUST have one of the labels: pre-alpha, alpha, beta or release candidate.
+* A codebase version that is ready to use MUST only depend on other codebase versions that are also ready to use.
+* A codebase version that is not yet ready to use MUST have one of the labels: pre-alpha, alpha, beta or release candidate.
 * A codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`.
 
 ## Why this is important
 
-Clearly signalling a codebase's maturity helps others decide whether to reuse, invest in or contribute to it.
+Clearly signalling a codebase version's maturity helps others decide whether to reuse, invest in or contribute to it.
 
 ## What this does not do
 
@@ -38,8 +38,8 @@ Clearly signalling a codebase's maturity helps others decide whether to reuse, i
 
 ## Management: what you need to do
 
-* Make sure that services only rely on codebases of equal or greater maturity than the service. For example, don't use a beta codebase in a production service or a prototype codebase in a beta service.
-* If the codebase is not ready for general use, work with the developers to ensure the codebase is properly labeled:
+* Make sure that services only rely on codebase versions of equal or greater maturity than the service. For example, don't use a beta version of a codebase in a production service or an alpha codebase version in a beta service.
+* If the codebase version is not ready for general use, work with the developers to ensure the version is properly labeled:
   * pre-alpha: to test the look and feel, and to internally prove the concept of the technical possibilities,
   * alpha: to do guided tests with a limited set of users,
   * beta: to open up testing to a larger section of the general public, for example to test if the codebase works at scale,

--- a/docs/review-template.md
+++ b/docs/review-template.md
@@ -218,5 +218,5 @@ Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
 A codebase MUST be versioned. |  |
 A codebase that is ready to use MUST only depend on other codebases that are also ready to use. |  |
-A codebase that is not yet ready to use MUST have one of the labels: prototype, alpha, beta or pre-release version. |  |
+A codebase that is not yet ready to use MUST have one of the labels: pre-alpha, alpha, beta or release candidate. |  |
 A codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`. |  |


### PR DESCRIPTION
This sketches out a tightly related problem to https://github.com/publiccodenet/standard/pull/729 ... that labels make sense for a version of a codebase as often there are multiple supported versions of a codebase at the same time as there are beta releases.

-----
[View rendered criteria/document-maturity.md](https://github.com/publiccodenet/standard/blob/lifecycle-version-labels/criteria/document-maturity.md)
[View rendered docs/review-template.md](https://github.com/publiccodenet/standard/blob/lifecycle-version-labels/docs/review-template.md)