### PR TITLE
Change version badge from red to yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The Standard for Public Code gives public organizations a model for preparing open source solutions to enable collaborations with similar public organizations in other places.
 It includes guidance for policy makers, city administrators, developers and vendors.
 
-![version 0.4.0](https://img.shields.io/badge/version-0.4.0-red.svg)
+![version 0.4.0](https://img.shields.io/badge/version-0.4.0-yellow.svg)
 ![Test](https://github.com/publiccodenet/standard/workflows/Test/badge.svg)
 ![Scheduled link check](https://github.com/publiccodenet/standard/workflows/Scheduled%20link%20check/badge.svg)
 


### PR DESCRIPTION
Yellow is commonly a warning color, where as red is commonly an error color. We wish to warn that this is a draft, subject to change, but it is a pre-release that can be tested today, more like a release candidate than an unstable alpha, thus yellow more closely communicates that level of warning.

-----
[View rendered README.md](https://github.com/publiccodenet/standard/blob/yellow-badge-of-courage/README.md)