### PR TITLE
move mdl exceptions from script to .mdlrc/.mdl_style.rb

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2021-2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS
+
+# Lint markdown using the Markdownlint gem with the default ruleset
+all
+# except for:
+
+# MD007 Unordered list indentation: we allow sub-lists to also have bullets
+exclude_rule 'MD007'
+
+# MD013 Line length: we allow long lines
+exclude_rule 'MD013'
+
+# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
+exclude_rule 'MD029'
+
+# Temporary hack to deal with weasyprint, see commit 831def8c3382
+# MD033 Inline HTML: hack in criteria/code-in-the-open.md line 53
+exclude_rule 'MD033'

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS
+
+style './.mdl_style.rb'

--- a/404.md
+++ b/404.md
@@ -4,6 +4,8 @@ title: Page not found
 toc: false
 ---
 
+# 404 Not Found
+
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
 

--- a/CC0-1.0.md
+++ b/CC0-1.0.md
@@ -5,16 +5,16 @@ redirect_from:
     - LICENSE.html
 ---
 
+# Creative Commons Zero v1.0 Universal
+
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
 
 <!-- TODO FIXME: move styling to the proper place, not inline html -->
 <style>.highlight { flex: 2 2 80%; max-width: 100%; } </style>
 
-# Creative Commons Zero v1.0 Universal
-
 This license is the legal contract that allows anyone to do anything they like with the content in this entire document.
 
-```
+```text
 {% include_relative LICENSE %}
 ```

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -1,6 +1,7 @@
+# Printing
+
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2021-2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
-# Printing
 
 The printed Standard for Public Code is printed by Reclameland.
 This guide tries to provide the relevant information to print it there or somewhere else.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,7 @@
+# Releasing a new version of the Standard for public code
+
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2021-2022 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
-# Releasing a new version of the Standard for public code
 
 1. Review state of the 'develop' branch
     - Ensure all changes intended for release are merged

--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -9,11 +9,5 @@
 # that new Markdown is valid and conforms to the repository guidelines. This
 # script is intended to aid in that process.
 
-# Lint markdown using the Markdownlint gem with the default ruleset except for:
-# MD007 Unordered list indentation: we allow sub-lists to also have bullets
-# MD013 Line length: we allow long lines
-# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
-#
-# Temporary hack to deal with weasyprint, see commit 831def8c3382
-# MD033 Inline HTML: hack in criteria/code-in-the-open.md line 53
-bundle exec mdl -r ~MD007,~MD013,~MD029,~MD033 -i -g '.'
+# Lint markdown using the rules loaded with .mdlrc, .mdl_style.rb
+bundle exec mdl -i -g '.'


### PR DESCRIPTION
This opens the door for greater control over mdl.