### PR TITLE
Ignore belastingdienst.nl, causes regular failures

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -26,6 +26,7 @@ bundle exec jekyll build
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * opensource.org : gives "failed: 503 No error" when run as GitHub workflow
+# * belastingdienst.nl/wps/wcm/connect/bldcontenten : regular timeouts
 # * reclameland.nl : often "failed: 403 No error" when run as GitHub workflow
 # * www.dta.gov.au : often "failed: 403 No error" when run as GitHub workflow
 # * 127.0.0.1 : localhost does not need to be checked
@@ -35,6 +36,7 @@ URL_IGNORE_REGEXES="\
 ,/docs\.github\.com\/en\//\
 ,/plausible\.io\/js\/plausible\.js/\
 ,/opensource\.org/\
+,/belastingdienst\.nl\/wps\/wcm\/connect\/bldcontenten/\
 ,/reclameland\.nl\/drukken\/softcover-boeken/\
 ,/www\.dta\.gov\.au\/help-and-advice/\
 ,/127\.0\.0\.1:/\


### PR DESCRIPTION
https://github.com/publiccodenet/standard/actions/workflows/link-check.yml

https://github.com/publiccodenet/standard/actions/runs/3717968772/jobs/6305814648

```
 Checking 152 external links...
- ./_site/changelog/changelog-0.3.0.html
Ran on 52 files!
  *  External link https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/business-public-benefit-organisations/public_benefit_organisations/what_is_pbo/what_is_a_pbo failed: response code 0 means something's wrong.

             It's possible libcurl couldn't connect to the server or perhaps the request timed out.

             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Failure when receiving data from the peer

HTML-Proofer found 1 failure!
Error: Process completed with exit code 1.
```