### PR TITLE
Only run linkcheck on publiccodenet/standard

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,6 +21,7 @@ defaults:
 
 jobs:
   cibuild:
+    if: ${{ github.repository == "publiccodenet/standard" }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   cibuild:
-    if: ${{ github.repository == "publiccodenet/standard" }}
+    if: ${{ github.repository == 'publiccodenet/standard' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Thanks to @rgs and @niven!

Only run the Scheduled link check's "cibuild" if the repository is `publiccodenet/standard`, so that forks do not have to deal with failing jobs.

fixes #799