### PR TITLE
Add applying the standard section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ The Standard for Public Code is in a draft format.
 We are preparing it for a version 1.0 release.
 Currently, we are testing it on a small number of codebases.
 
+## Applying the Standard for Public Code on your codebase
+
+If you want to apply the Standard for Public Code to your codebase, just go ahead, it's an open standard and free for anyone to use.
+To see how ready your codebase is, you can do a quick [eligibility self assessment](https://publiccodenet.github.io/assessment-eligibility) that will give you some rough expectations on how much work you may need to do to meet all criteria.
+
+The standard *should* be mostly self-explanatory in how to apply it on your codebase.
+If anything in the standard is unclear, we encourage you to open an issue here so that we can help you and everyone else who feel the same as you.
+For inspiration, look at the [Community built implementation guide](https://publiccodenet.github.io/community-implementation-guide-standard/) which contains examples and other tips.
+
+If there are any breaking changes in a new version of the Standard for Public Code, the codebase stewards at the Foundation for Public Code will help any implementors of the standard to understand how the gaps can be closed.
+
+If you want to commit your codebase to become fully compliant to the standard for future certification, please contact us at <info@publiccode.net> to initiate a formal [assessment](https://about.publiccode.net/activities/codebase-stewardship/lifecycle-diagram.html#assessment).
+
 ## Request for contributions
 
 We believe public policy and software should be inclusive, usable, open, legible, accountable, accessible and sustainable.


### PR DESCRIPTION
While we had good sections on contributing to the standard, we were missing a section on how to use it.

Also fixes #309