### PR TITLE
Improve security reporting requirements

### DIFF
--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -8,10 +8,10 @@ order: 5
 ## Requirements
 
 * The [codebase](../glossary.md#codebase) MUST have a public issue tracker that accepts suggestions from anyone.
-* The codebase MUST include instructions for how to privately report security issues for responsible disclosure.
 * The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
 * The codebase MUST have communication channels for users and developers, for example email lists.
-* The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel.
+* There MUST be a way to report security issues for responsible disclosure over a closed channel.
+* The documentation MUST include instructions for how to report potentially security sensitive issues.
 
 ## Why this is important
 
@@ -26,9 +26,10 @@ order: 5
 ## How to test
 
 * Confirm that there is a public issue tracker.
-* Confirm that there are instructions for privately reporting security issues.
 * Confirm that the codebase contains links to the public issue tracker and submitted codebase changes.
 * Confirm that it is possible to participate in a discussion with other users and developers about the software using channels described in the codebase.
+* Confirm that there is a closed channel for reporting security issues.
+* Confirm that there are instructions for privately reporting security issues.
 
 ## Policy makers: what you need to do
 


### PR DESCRIPTION
Since https://github.com/publiccodenet/standard/issues/339 was fixed by d0dbb84d94b3bd26427f5d2f37a0ced9687c039c the criterion has had two very similar statements.

After the https://github.com/publiccodenet/standard/issues/339 fix, the method of reporting is no longer specified,
but the documentation of the process is a MUST, while leaving the second requirement to document a SHOULD.

Instead we should have kept the focus of the first requirement on the existence of a closed channel, and changed the second to a MUST.

fixes #632