### PR TITLE
unlink glossary terms in review template

### DIFF
--- a/docs/review-template.md
+++ b/docs/review-template.md
@@ -11,45 +11,47 @@ Link to commitment to meet the Standard for Public Code:
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All source [code](https://standard.publiccode.net/glossary.html#code) for any [policy](https://standard.publiccode.net/glossary.html#policy) in use (unless used for fraud detection) MUST be published and publicly accessible. |  |
+All source code for any policy in use (unless used for fraud detection) MUST be published and publicly accessible. |  |
 All source code for any software in use (unless used for fraud detection) MUST be published and publicly accessible. |  |
-Contributors MUST NOT upload sensitive information regarding users, their organization or third parties to the [repository](https://standard.publiccode.net/glossary.html#repository). |  |
+The codebase MUST NOT contain sensitive information regarding users, their organization or third parties. |  |
 Any source code not currently in use (such as new versions, proposals or older versions) SHOULD be published. |  |
-Documenting which source code or policy underpins any specific interaction the [general public](https://standard.publiccode.net/glossary.html#general-public) may have with an organization is OPTIONAL. |  |
+Documenting which source code or policy underpins any specific interaction the general public may have with an organization is OPTIONAL. |  |
 
-## [Bundle policy and source code](https://standard.publiccode.net/criteria/bundle-policy-and-code.html)
+## [Bundle policy and source code](https://standard.publiccode.net/criteria/bundle-policy-and-source-code.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST include the [policy](https://standard.publiccode.net/glossary.html#policy) that the source [code](https://standard.publiccode.net/glossary.html#code) is based on. |  |
+The codebase MUST include the policy that the source code is based on. |  |
 The codebase MUST include all source code that the policy is based on, unless used for fraud detection. |  |
 Policy SHOULD be provided in machine readable and unambiguous formats. |  |
-[Continuous integration](https://standard.publiccode.net/glossary.html#continuous-integration) tests SHOULD validate that the source code and the policy are executed coherently. |  |
+Continuous integration tests SHOULD validate that the source code and the policy are executed coherently. |  |
 
-## [Create reusable and portable code](https://standard.publiccode.net/criteria/reusable-and-portable-codebases.html)
+## [Create reusable and portable code](https://standard.publiccode.net/criteria/create-reusable-and-portable-code.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST be developed to be reusable in [different contexts](https://standard.publiccode.net/glossary.html#different-contexts). |  |
-The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed [code](https://standard.publiccode.net/glossary.html#code) or services for execution and understanding. |  |
+The codebase MUST be developed to be reusable in different contexts. |  |
+The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding. |  |
 The codebase SHOULD be in use by multiple parties. |  |
 The roadmap SHOULD be influenced by the needs of multiple parties. |  |
+The development of the codebase SHOULD be a collaboration between multiple parties. |  |
 Configuration SHOULD be used to make code adapt to context specific needs. |  |
 The codebase SHOULD be localizable. |  |
 Code and its documentation SHOULD NOT contain situation-specific information. |  |
 Codebase modules SHOULD be documented in such a way as to enable reuse in codebases in other contexts. |  |
+The code SHOULD NOT require services or platforms available from only a single vendor. |  |
 
-## [Welcome contributors](https://standard.publiccode.net/criteria/open-to-contributions.html)
+## [Welcome contributors](https://standard.publiccode.net/criteria/welcome-contributors.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST allow anyone to submit suggestions for changes to the codebase. |  |
+The codebase MUST allow anyone to submit suggestions for changes to the codebase. |  |
 The codebase MUST include contribution guidelines explaining what kinds of contributions are welcome and how contributors can get involved, for example in a `CONTRIBUTING` file. |  |
 The codebase MUST document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file. |  |
 The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance. |  |
@@ -63,91 +65,90 @@ Including a code of conduct for contributors in the codebase is OPTIONAL. |  |
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST have a public issue tracker that accepts suggestions from anyone. |  |
-The codebase MUST include instructions for how to privately report security issues for responsible disclosure. |  |
+The codebase MUST have a public issue tracker that accepts suggestions from anyone. |  |
 The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file. |  |
 The codebase MUST have communication channels for users and developers, for example email lists. |  |
-The documentation SHOULD include instructions for how to report potentially security sensitive issues on a closed channel. |  |
+There MUST be a way to report security issues for responsible disclosure over a closed channel. |  |
+The documentation MUST include instructions for how to report potentially security sensitive issues. |  |
 
-## [Maintain version control](https://standard.publiccode.net/criteria/version-control-and-history.html)
+## [Maintain version control](https://standard.publiccode.net/criteria/maintain-version-control.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The community MUST have a way to maintain [version control](https://standard.publiccode.net/glossary.html#version-control) for the [code](https://standard.publiccode.net/glossary.html#code). |  |
-All files in the [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST be version controlled. |  |
+All files in the codebase MUST be version controlled. |  |
 All decisions MUST be documented in commit messages. |  |
 Every commit message MUST link to discussions and issues wherever possible. |  |
 The codebase SHOULD be maintained in a distributed version control system. |  |
-Contributors SHOULD group relevant changes in commits. |  |
+Contribution guidelines SHOULD require contributors to group relevant changes in commits. |  |
 Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels. |  |
-Contributors SHOULD prefer file formats where the changes within the files can be easily viewed and understood in the version control system. |  |
+Contribution guidelines SHOULD encourage file formats where the changes within the files can be easily viewed and understood in the version control system. |  |
 It is OPTIONAL for contributors to sign their commits and provide an email address, so that future contributors are able to contact past contributors with questions about their work. |  |
 
-## [Require review of contributions](https://standard.publiccode.net/criteria/require-review.html)
+## [Require review of contributions](https://standard.publiccode.net/criteria/require-review-of-contributions.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All contributions that are accepted or committed to release versions of the [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST be reviewed by another contributor. |  |
-Reviews MUST include source, [policy](https://standard.publiccode.net/glossary.html#policy), tests and documentation. |  |
+All contributions that are accepted or committed to release versions of the codebase MUST be reviewed by another contributor. |  |
+Reviews MUST include source, policy, tests and documentation. |  |
 Reviewers MUST provide feedback on all decisions to not accept a contribution. |  |
 Contributions SHOULD conform to the standards, architecture and decisions set out in the codebase in order to pass review. |  |
-Reviews SHOULD include running both the [code](https://standard.publiccode.net/glossary.html#code) and the tests of the codebase. |  |
+Reviews SHOULD include running both the code and the tests of the codebase. |  |
 Contributions SHOULD be reviewed by someone in a different context than the contributor. |  |
 Version control systems SHOULD NOT accept non-reviewed contributions in release versions. |  |
 Reviews SHOULD happen within two business days. |  |
 Performing reviews by multiple reviewers is OPTIONAL. |  |
 
-## [Document codebase objectives](https://standard.publiccode.net/criteria/document-objectives.html)
+## [Document codebase objectives](https://standard.publiccode.net/criteria/document-codebase-objectives.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST contain documentation of its objectives, like a mission and goal statement, that is understandable by developers and designers so that they can use or contribute to the codebase. |  |
-Codebase documentation SHOULD clearly describe the connections between [policy](https://standard.publiccode.net/glossary.html#policy) objectives and codebase objectives. |  |
-Documenting the objectives of the codebase for the [general public](https://standard.publiccode.net/glossary.html#general-public) is OPTIONAL. |  |
+The codebase MUST contain documentation of its objectives, like a mission and goal statement, that is understandable by developers and designers so that they can use or contribute to the codebase. |  |
+Codebase documentation SHOULD clearly describe the connections between policy objectives and codebase objectives. |  |
+Documenting the objectives of the codebase for the general public is OPTIONAL. |  |
 
-## [Document the code](https://standard.publiccode.net/criteria/documenting.html)
+## [Document the code](https://standard.publiccode.net/criteria/document-the-code.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All of the functionality of the [codebase](https://standard.publiccode.net/glossary.html#codebase), [policy](https://standard.publiccode.net/glossary.html#policy) as well as source, MUST be described in language clearly understandable for those that understand the purpose of the [code](https://standard.publiccode.net/glossary.html#code). |  |
+All of the functionality of the codebase, policy as well as source, MUST be described in language clearly understandable for those that understand the purpose of the code. |  |
 The documentation of the codebase MUST contain a description of how to install and run the source code. |  |
 The documentation of the codebase MUST contain examples demonstrating the key functionality. |  |
-The documentation of the codebase SHOULD contain a high level description that is clearly understandable for a wide audience of stakeholders, like the [general public](https://standard.publiccode.net/glossary.html#general-public) and journalists. |  |
+The documentation of the codebase SHOULD contain a high level description that is clearly understandable for a wide audience of stakeholders, like the general public and journalists. |  |
 The documentation of the codebase SHOULD contain a section describing how to install and run a standalone version of the source code, including, if necessary, a test dataset. |  |
 The documentation of the codebase SHOULD contain examples for all functionality. |  |
 The documentation SHOULD describe the key components or modules of the codebase and their relationships, for example as a high level architectural diagram. |  |
-There SHOULD be [continuous integration](https://standard.publiccode.net/glossary.html#continuous-integration) tests for the quality of the documentation. |  |
+There SHOULD be continuous integration tests for the quality of the documentation. |  |
 Including examples that make users want to immediately start using the codebase in the documentation of the codebase is OPTIONAL. |  |
 
-## [Use plain English](https://standard.publiccode.net/criteria/understandable-english-first.html)
+## [Use plain English](https://standard.publiccode.net/criteria/use-plain-english.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All [codebase](https://standard.publiccode.net/glossary.html#codebase) documentation MUST be in English. |  |
-All [code](https://standard.publiccode.net/glossary.html#code) MUST be in English, except where [policy](https://standard.publiccode.net/glossary.html#policy) is machine interpreted as code. |  |
+All codebase documentation MUST be in English. |  |
+All code MUST be in English, except where policy is machine interpreted as code. |  |
 All bundled policy not available in English MUST have an accompanying summary in English. |  |
 Any translation MUST be up to date with the English version and vice versa. |  |
 There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation. |  |
 Documentation SHOULD aim for a lower secondary education reading level, as recommended by the [Web Content Accessibility Guidelines 2](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable). |  |
 Providing a translation of any code, documentation or tests is OPTIONAL. |  |
 
-## [Use open standards](https://standard.publiccode.net/criteria/open-standards.html)
+## [Use open standards](https://standard.publiccode.net/criteria/use-open-standards.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-For features of the [codebase](https://standard.publiccode.net/glossary.html#codebase) that facilitate the exchange of data the codebase MUST use an [open standard](https://standard.publiccode.net/glossary.html#open-standard) that meets the [Open Source Initiative Open Standard Requirements](https://opensource.org/osr). |  |
+For features of the codebase that facilitate the exchange of data the codebase MUST use an open standard that meets the [Open Source Initiative Open Standard Requirements](https://opensource.org/osr). |  |
 Any non-open standards used MUST be recorded clearly as such in the documentation. |  |
 Any standard chosen for use within the codebase MUST be listed in the documentation with a link to where it is available. |  |
 Any non-open standards chosen for use within the codebase MUST NOT hinder collaboration and reuse. |  |
@@ -155,69 +156,70 @@ If no existing open standard is available, effort SHOULD be put into developing 
 Open standards that are machine testable SHOULD be preferred over open standards that are not. |  |
 Non-open standards that are machine testable SHOULD be preferred over non-open standards that are not. |  |
 
-## [Use continuous integration](https://standard.publiccode.net/criteria/continuous-integration.html)
+## [Use continuous integration](https://standard.publiccode.net/criteria/use-continuous-integration.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All functionality in the source [code](https://standard.publiccode.net/glossary.html#code) MUST have automated tests. |  |
-Contributions MUST pass all automated tests before they are admitted into the [codebase](https://standard.publiccode.net/glossary.html#codebase). |  |
+All functionality in the source code MUST have automated tests. |  |
+Contributions MUST pass all automated tests before they are admitted into the codebase. |  |
 The codebase MUST have guidelines explaining how to structure contributions. |  |
 The codebase MUST have active contributors who can review contributions. |  |
+Automated test results for contributions SHOULD be public. |  |
 The codebase guidelines SHOULD state that each contribution should focus on a single issue. |  |
 Source code test and documentation coverage SHOULD be monitored. |  |
-Testing [policy](https://standard.publiccode.net/glossary.html#policy) and documentation for consistency with the source and vice versa is OPTIONAL. |  |
+Testing policy and documentation for consistency with the source and vice versa is OPTIONAL. |  |
 Testing policy and documentation for style and broken links is OPTIONAL. |  |
 Testing the code by using examples in the documentation is OPTIONAL. |  |
 
-## [Publish with an open license](https://standard.publiccode.net/criteria/open-licenses.html)
+## [Publish with an open license](https://standard.publiccode.net/criteria/publish-with-an-open-license.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-All [code](https://standard.publiccode.net/glossary.html#code) and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable. |  |
+All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable. |  |
 Software source code MUST be licensed under an [OSI-approved or FSF Free/Libre license](https://spdx.org/licenses/). |  |
 All code MUST be published with a license file. |  |
-Contributors MUST NOT be required to transfer copyright of their contributions to the [codebase](https://standard.publiccode.net/glossary.html#codebase). |  |
+Contributors MUST NOT be required to transfer copyright of their contributions to the codebase. |  |
 All source code files in the codebase SHOULD include a copyright notice and a license header that are machine-readable. |  |
 Having multiple licenses for different types of code and documentation is OPTIONAL. |  |
 
-## [Make the codebase findable](https://standard.publiccode.net/criteria/findability.html)
+## [Make the codebase findable](https://standard.publiccode.net/criteria/make-the-codebase-findable.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST be findable using a search engine by describing the problem it solves in natural language. |  |
+The codebase MUST be findable using a search engine by describing the problem it solves in natural language. |  |
 The codebase MUST be findable using a search engine by codebase name. |  |
 The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding. |  |
 Maintainers SHOULD submit the codebase to relevant software catalogs. |  |
 The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers). |  |
-The codebase SHOULD have a unique and persistent identifier where the entry mentions the major contributors, [repository](https://standard.publiccode.net/glossary.html#repository) location and website. |  |
+The codebase SHOULD have a unique and persistent identifier where the entry mentions the major contributors, repository location and website. |  |
 The codebase SHOULD include a machine-readable metadata description, for example in a [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) file. |  |
 A dedicated domain name for the codebase is OPTIONAL. |  |
 Regular presentations at conferences by the community are OPTIONAL. |  |
 
-## [Use a coherent style](https://standard.publiccode.net/criteria/style.html)
+## [Use a coherent style](https://standard.publiccode.net/criteria/use-a-coherent-style.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase. |  |
+The codebase MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase. |  |
 Contributions SHOULD pass automated tests on style. |  |
 The style guide SHOULD include expectations for inline comments and documentation for non-trivial sections. |  |
-Including expectations for [understandable English](https://standard.publiccode.net/criteria/understandable-english-first.html) in the style guide is OPTIONAL. |  |
+Including expectations for [understandable English](https://standard.publiccode.net/criteria/use-plain-english.html) in the style guide is OPTIONAL. |  |
 
-## [Document codebase maturity](https://standard.publiccode.net/criteria/document-maturity.html)
+## [Document codebase maturity](https://standard.publiccode.net/criteria/document-codebase-maturity.html)
 
 &#9744; criterion met.
 
 Requirement | meets | &nbsp;links&nbsp;and&nbsp;notes&nbsp;
 -----|-----|-----
-The [codebase](https://standard.publiccode.net/glossary.html#codebase) MUST be versioned. |  |
+The codebase MUST be versioned. |  |
 The codebase MUST prominently document whether or not there are versions of the codebase that are ready to use. |  |
 Codebase versions that are ready to use MUST only depend on versions of other codebases that are also ready to use. |  |
 The codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`. |  |

--- a/script/generate-review-template.sh
+++ b/script/generate-review-template.sh
@@ -54,8 +54,8 @@ done
 
 cp -v $TEMPLATE $TEMPLATE.orig
 
-# fully qualify glossary local links in requirement lines
-sed -i -e's@\[\([^]]*\)\](../glossary.md\(#[a-z\-]*\))@[\1](https://standard.publiccode.net/glossary.html\2)@g' $TEMPLATE
+# unlink glossary local links in requirement lines
+sed -i -e's@\[\([^]]*\)\](../glossary.md\(#[a-z\-]*\))@\1@g' $TEMPLATE
 
 # fully qualify local criteria links in requirement lines
 # by looking for links lacking a colon


### PR DESCRIPTION
Since b60c9c4 fewer of the criteria have glossary terms linked. The remaining ones now are out-of-place.
This unlinks those pages for now.
If we want links, we should ensure the first usage of each term is linked.