### PR TITLE
Lower significance of search engine requirements

### DIFF
--- a/criteria/make-the-codebase-findable.md
+++ b/criteria/make-the-codebase-findable.md
@@ -16,24 +16,22 @@ Well-written metadata containing a unique and persistent identifier, such as a W
 
 ## Requirements
 
-* The codebase MUST be findable using a search engine by describing the problem it solves in natural language.
-* The codebase MUST be findable using a search engine by codebase name.
 * The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.
 * Maintainers SHOULD submit the codebase to relevant software catalogs.
 * The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).
+* It is SHOULD for the codebase to be findable using a search engine by codebase name.
 * The codebase SHOULD have a unique and persistent identifier where the entry mentions the major contributors, [repository](../glossary.md#repository) location and website.
 * The codebase SHOULD include a machine-readable metadata description, for example in a [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) file.
+* It is OPTIONAL for the codebase to be findable using a search engine by describing the problem it solves in natural language.
 * A dedicated domain name for the codebase is OPTIONAL.
 * Regular presentations at conferences by the community are OPTIONAL.
 
 ## How to test
 
-* Confirm that the codebase appears in the results on more than one major search engine when searching by a plain English problem description.
-* Confirm that the codebase appears in the results on more than one major search engine when searching by a technical problem description.
-* Confirm that the codebase appears in the results on more than one major search engine when searching by the codebase name.
 * Check that the codebase name is free of acronyms, abbreviations, puns or organizational branding.
 * Check for the codebase listing in relevant software catalogs.
 * Check for a codebase website which describes the problem the codebase solves.
+* Check that the codebase appears in the results on more than one major search engine when searching by the codebase name.
 * Check unique and persistent identifier entries for mention of the major contributors.
 * Check unique and persistent identifier entries for the repository location.
 * Check unique and persistent identifier entries for the codebase website.
@@ -47,9 +45,9 @@ Well-written metadata containing a unique and persistent identifier, such as a W
 
 ## Managers: what you need to do
 
+* Search trademark databases to avoid confusion or infringement before deciding the name.
 * Budget for content design and Search Engine Optimization skills in the team.
 * Make sure people involved in the project present at relevant conferences.
-* Search trademark databases to avoid confusion or infringement before deciding the name.
 
 ## Developers and designers: what you need to do
 


### PR DESCRIPTION
As the results of the search engines are largely out of control for a codebase, these requirements need lower significance.

Fixes #896