### PR TITLE
Allow workflow trigger by hand

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,6 +3,7 @@
 
 name: Scheduled link check
 on:
+  workflow_dispatch: {}
   schedule:
 #             ┌───────────── minute (0 - 59)
 #             │ ┌───────────── hour (0 - 23)


### PR DESCRIPTION
I *think* this is the correct syntax to allow both by-hand triggering and trigger on a schedule.