### PR TITLE
unschedule local link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2021-2023 The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS
 
-name: Scheduled link check
+name: local link check
 on:
   workflow_dispatch: {}
-  schedule:
+#  schedule:
 #             ┌───────────── minute (0 - 59)
 #             │ ┌───────────── hour (0 - 23)
 #             │ │ ┌───────────── day of the month (1 - 31)
@@ -14,7 +14,7 @@ on:
 #             │ │ │ │ │
 #             │ │ │ │ │
 #             * * * * *
-    - cron:  '7 1 * * *' # every day at 01:07 (UTC?)
+#    - cron:  '7 1 * * *' # every day at 01:07 (UTC?)
 
 defaults:
   run:


### PR DESCRIPTION
can still be run manually.

see also:

https://publiccodenet.github.io/publiccodenet-url-check/