### PR TITLE
README badges link to "look" links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ It includes guidance for policy makers, city administrators, developers and vend
 
 [![pages-build-deployment](https://github.com/publiccodenet/standard/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/publiccodenet/standard/actions/workflows/pages/pages-build-deployment)
 [![Test](https://github.com/publiccodenet/standard/actions/workflows/test.yml/badge.svg)](https://github.com/publiccodenet/standard/actions/workflows/test.yml)
-[![standard main badge](https://publiccodenet.github.io/publiccodenet-url-check/badges/standard.publiccode.net.svg)](https://publiccodenet.github.io/publiccodenet-url-check/url-check-fails.json)
-[![standard develop badge](https://publiccodenet.github.io/publiccodenet-url-check/badges/standard.publiccode.net-develop.svg)](https://publiccodenet.github.io/publiccodenet-url-check/url-check-fails.json)
+[![standard main badge](https://publiccodenet.github.io/publiccodenet-url-check/badges/standard.publiccode.net.svg)](https://publiccodenet.github.io/publiccodenet-url-check/standard.publiccode.net-url-check-look.json)
+[![standard develop badge](https://publiccodenet.github.io/publiccodenet-url-check/badges/standard.publiccode.net-develop.svg)](https://publiccodenet.github.io/publiccodenet-url-check/standard.publiccode.net-develop-url-check-look.json)
 
 The Standard for Public Code is in a draft format.
 We are preparing it for a version 1.0 release.


### PR DESCRIPTION
As of:
 https://github.com/publiccodenet/url-check/commit/b3e0bb952eb624b357b8286eba8b89e16968d001
the url-check now links the "-look.json" to the most relevant report: the condensed report on failure, the full report on success