### PR TITLE
Update version number of assessment

### DIFF
--- a/docs/standard-for-public-code.html
+++ b/docs/standard-for-public-code.html
@@ -4,7 +4,7 @@
 <!-- SPDX-FileCopyrightText: 2022-2023 by The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
 <head>
 <meta charset="UTF-8">
-<title>The Standard for Public Code's compliance to the criteria and requirements of the Standard for Public Code version 0.6.0</title>
+<title>The Standard for Public Code's compliance to the criteria and requirements of the Standard for Public Code version 0.7.0</title>
 <style>
 html, body {
 font-family: Mulish;
@@ -45,7 +45,7 @@ background-color: #f6f8fa;
 </style>
 </head>
 <body>
-<h1>The Standard for Public Code's compliance to the criteria and requirements of the Standard for Public Code version 0.6.0</h1>
+<h1>The Standard for Public Code's compliance to the criteria and requirements of the Standard for Public Code version 0.7.0</h1>
 
 The Standard for Public Code is not a codebase created in the context of a policy mandate, thus some criteria do not apply directly.
 


### PR DESCRIPTION
We forgot to change the number when adding the requirements for 0.7.0.