### PR TITLE
Use "machine-readable" consistently

### DIFF
--- a/criteria/bundle-policy-and-source-code.md
+++ b/criteria/bundle-policy-and-source-code.md
@@ -17,7 +17,7 @@ To be able to evaluate whether to implement a codebase in a new context, an orga
 
 * The codebase MUST include the policy that the source code is based on.
 * If a policy is based on source code, that source code MUST be included in the codebase, unless used for fraud detection.
-* Policy SHOULD be provided in machine readable and unambiguous formats.
+* Policy SHOULD be provided in machine-readable and unambiguous formats.
 * [Continuous integration](../glossary.md#continuous-integration) tests SHOULD validate that the source code and the policy are executed coherently.
 
 ## How to test

--- a/docs/checklist.html
+++ b/docs/checklist.html
@@ -51,7 +51,7 @@ list-style-type: "\2610";
 <ul id="bundle-policy-and-source-code">
 <li>The codebase MUST include the policy that the source code is based on. </li>
 <li>If a policy is based on source code, that source code MUST be included in the codebase, unless used for fraud detection. </li>
-<li>Policy SHOULD be provided in machine readable and unambiguous formats. </li>
+<li>Policy SHOULD be provided in machine-readable and unambiguous formats. </li>
 <li>Continuous integration tests SHOULD validate that the source code and the policy are executed coherently. </li>
 </ul>
 

--- a/docs/review-template.html
+++ b/docs/review-template.html
@@ -152,7 +152,7 @@ If a policy is based on source code, that source code MUST be included in the co
 
 </td>
 <td>
-Policy SHOULD be provided in machine readable and unambiguous formats.
+Policy SHOULD be provided in machine-readable and unambiguous formats.
 </td>
 <td>
 

--- a/docs/standard-for-public-code.html
+++ b/docs/standard-for-public-code.html
@@ -154,7 +154,7 @@ If a policy is based on source code, that source code MUST be included in the co
 N/A
 </td>
 <td>
-Policy SHOULD be provided in machine readable and unambiguous formats.
+Policy SHOULD be provided in machine-readable and unambiguous formats.
 </td>
 <td>
 


### PR DESCRIPTION
In most cases we have "machine-readable" but we had one case of "machine readable". Fixed with:

```
sed -i -e's/machine readable/machine-readable/g' \
	$(git grep -l 'machine readable')
```