### PR TITLE
ignore `.bundle/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _site
 _build_pdf
 *.pdf
 *.epub
+.bundle/
 vendor/
 urls-sorted.txt
 urls.txt


### PR DESCRIPTION
with the newer ruby bundler, it stores config locally in the .bundle/ directory; let's `git ignore` that