### PR TITLE
Rather than hard-code port 9000, find a free one

### DIFF
--- a/script/pdf.sh
+++ b/script/pdf.sh
@@ -66,7 +66,15 @@ function ensure_good_weasyprint () {
 }
 ensure_good_weasyprint
 
-JEKYLL_PDF_PORT=9000
+function free-port() {
+	ruby -e 'require "socket";
+		s=TCPServer.new("", 0);
+		print s.addr[1], "\n";
+		s.close();'
+}
+
+JEKYLL_PDF_PORT=$(free-port)
+echo "JEKYLL_PDF_PORT=$JEKYLL_PDF_PORT"
 JEKYLL_PDF_DIR=_build_pdf
 rm -rf $JEKYLL_PDF_DIR
 


### PR DESCRIPTION
The Ruby TCPServer.new() when given a port of 0 will initialize to a valid available port.

This prints that and closes it, after which it is
available again for us to use.

There is, of course, a remote race condition where another process grabs that same port between the
TCPServer.close() and the open() from Jekyll, but
that is also possible with a hard-coded port.