### PR TITLE
Simplify language in Document the code

### DIFF
--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -19,7 +19,7 @@ It also makes contributing to the codebase easier.
 * The documentation SHOULD contain an overview that is easy to understand by a wide audience. The audience includes the [general public](../glossary.md#general-public) and journalists.
 * The documentation SHOULD contain a section describing how to install and run a standalone version of the software. This includes a test dataset if necessary.
 * The documentation SHOULD contain examples for all functionality.
-* The documentation SHOULD describe the key components or modules and their relationships. For example, as a high level architectural diagram.
+* The documentation SHOULD describe the key components or modules and their relationships. For example, this could be done as a high level architectural diagram.
 * There SHOULD be [continuous integration](../glossary.md#continuous-integration) tests for the quality of the documentation.
 * Including examples that make users want to immediately start using the codebase in the documentation of the codebase is OPTIONAL.
 

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -17,7 +17,7 @@ It also makes contributing to the codebase easier.
 * The documentation MUST contain a description of how to install and run the software.
 * The documentation MUST contain examples demonstrating the key functionality.
 * The documentation SHOULD contain an overview that is easy to understand by a wide audience. The audience includes the [general public](../glossary.md#general-public) and journalists.
-* The documentation SHOULD contain a section describing how to install and run a standalone version of the software. This includes, if necessary, a test dataset.
+* The documentation SHOULD contain a section describing how to install and run a standalone version of the software. This includes a test dataset if necessary.
 * The documentation SHOULD contain examples for all functionality.
 * The documentation SHOULD describe the key components or modules and their relationships. For example, as a high level architectural diagram.
 * There SHOULD be [continuous integration](../glossary.md#continuous-integration) tests for the quality of the documentation.

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -8,30 +8,31 @@ redirect_from:
 # Document the code
 
 Well documented [source code](../glossary.md#source-code) helps people to understand what the source code does and how to use it.
-Documentation is essential for people to start using the [codebase](../glossary.md#codebase) and contributing to it more quickly.
+Documentation is essential for people to start using the [codebase](../glossary.md#codebase).
+It also makes contributing to it easier.
 
 ## Requirements
 
-* All of the functionality of the codebase, [policy](../glossary.md#policy) as well as source code, MUST be described in language clearly understandable for those that understand the purpose of the codebase.
-* The documentation of the codebase MUST contain a description of how to install and run the software.
-* The documentation of the codebase MUST contain examples demonstrating the key functionality.
-* The documentation of the codebase SHOULD contain a high level description that is clearly understandable for a wide audience of stakeholders, like the [general public](../glossary.md#general-public) and journalists.
-* The documentation of the codebase SHOULD contain a section describing how to install and run a standalone version of the source code, including, if necessary, a test dataset.
-* The documentation of the codebase SHOULD contain examples for all functionality.
-* The documentation SHOULD describe the key components or modules of the codebase and their relationships, for example as a high level architectural diagram.
+* All functionality MUST be described in a clear language. The audience is those that understand the purpose of the codebase.
+* The documentation MUST contain a description of how to install and run the software.
+* The documentation MUST contain examples demonstrating the key functionality.
+* The documentation SHOULD contain an overview that is easy to understand by a wide audience. The audience includes the [general public](../glossary.md#general-public) and journalists.
+* The documentation SHOULD contain a section describing how to install and run a standalone version of the software. This includes, if necessary, a test dataset.
+* The documentation SHOULD contain examples for all functionality.
+* The documentation SHOULD describe the key components or modules and their relationships. For example, as a high level architectural diagram.
 * There SHOULD be [continuous integration](../glossary.md#continuous-integration) tests for the quality of the documentation.
 * Including examples that make users want to immediately start using the codebase in the documentation of the codebase is OPTIONAL.
 
 ## How to test
 
-* Confirm that other stakeholders, professionals from other public organizations and the general public find the documentation clear and understandable.
+* Confirm that other stakeholders find the documentation clear and understandable. Stakeholders are professionals from other public organizations and the general public.
 * Confirm that the documentation describes how to install and run the source code.
 * Confirm that the documentation includes examples of the key functionality.
-* Check with members of the general public and journalists if they can understand the high level description.
+* Check with members of the general public and journalists if they can understand the overview.
 * Check that the instructions for how to install and run a standalone version of the source code result in a running system.
 * Check that all functionality documented contains an example.
 * Check that the documentation includes a high level architectural diagram or similar.
-* Check that the documentation quality is part of integration testing, for example documentation is generated correctly, and links and images are tested.
+* Check that the documentation quality is part of integration testing. For example, that documentation is generated correctly, and links and images are tested.
 
 ## Public policy makers: what you need to do
 
@@ -40,7 +41,7 @@ Documentation is essential for people to start using the [codebase](../glossary.
 
 ## Managers: what you need to do
 
-* Try to use the codebase, so your feedback can improve how clearly the policy and source code are documented. For example, is the current documentation sufficient to persuade a manager at another public organization to use this codebase?
+* Try to use the codebase so that you can provide feedback. This can improve how the [policy](../glossary.md#policy) and source code are documented. For example, is the documentation good enough to persuade a manager at another public organization to use this codebase?
 * Make sure you understand both the policy and source code as well as the documentation.
 
 ## Developers and designers: what you need to do

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -9,7 +9,7 @@ redirect_from:
 
 Well documented [source code](../glossary.md#source-code) helps people to understand what the source code does and how to use it.
 Documentation is essential for people to start using the [codebase](../glossary.md#codebase).
-It also makes contributing to it easier.
+It also makes contributing to the codebase easier.
 
 ## Requirements
 

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -32,7 +32,7 @@ It also makes contributing to the codebase easier.
 * Check that the instructions for how to install and run a standalone version of the source code result in a running system.
 * Check that all functionality documented contains an example.
 * Check that the documentation includes a high level architectural diagram or similar.
-* Check that the documentation quality is part of integration testing. For example, that documentation is generated correctly, and links and images are tested.
+* Check that documentation quality is part of integration testing. For example, test that documentation is generated correctly, and test links and images.
 
 ## Public policy makers: what you need to do
 

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -25,7 +25,7 @@ It also makes contributing to the codebase easier.
 
 ## How to test
 
-* Confirm that other stakeholders find the documentation clear and understandable. Stakeholders are professionals from other public organizations and the general public.
+* Confirm that other stakeholders find the documentation clear and understandable. Stakeholders should include professionals from other public organizations and the general public.
 * Confirm that the documentation describes how to install and run the source code.
 * Confirm that the documentation includes examples of the key functionality.
 * Check with members of the general public and journalists if they can understand the overview.


### PR DESCRIPTION
As shown in #1007, this was the worst scoring criterion. This change aims to simplify the language, excluding the requirement mentioned in #1015.

(This PR is also a pilot for simplifying the language all over.)